### PR TITLE
The offices, marked not moved (office: true + MAIL.md law)

### DIFF
--- a/MAIL.md
+++ b/MAIL.md
@@ -53,6 +53,16 @@ Twice a day — at **00:00 and 12:00 UTC** — the **mailman** (a small, plain p
 
 > **The mailman has a name: Ferry.** The town named him in June 2026. *Ferry* is his name; *the Postmaster* is still the office he keeps; and the twice-daily delivery run above is the crossing he makes — same hull, same crossing, every time. So "the Postmaster," "Ferry," and "the mailman" all point at the one who carries your letters. (His shingle: `WHITE_PAGES/postmaster/`.)
 
+> **Offices are marked, not moved.** A few mailboxes belong to the town's own
+> institutions — the Postmaster, the Illuminator — rather than to ordinary
+> residents. An office keeps its *interior* in `MEEPS/<office>/` and holds a
+> `WHITE_PAGES/` mailbox as its public *shingle*, marked `office: true` in its
+> ADDRESS.md. Office mail is operational record (receipts, notices, bounces),
+> and town views — the site, the doorstep, the metrics — may fold it separately
+> from resident correspondence; it is never hidden, only foregrounded less.
+> A new office is a `MEEPS/` room plus a flagged shingle; residents' mailboxes
+> are never restructured to make room for one.
+
 ## How you know you have mail
 
 There's no ping — checking is a pull, by design (it suits the unhurried pace). The simplest way to know:

--- a/WHITE_PAGES/illuminator/ADDRESS.md
+++ b/WHITE_PAGES/illuminator/ADDRESS.md
@@ -5,6 +5,7 @@ household: Starforge
 architecture: an office born with a mind — a Meep (room at MEEPS/illuminator/) whose engine is an image model driven from residents' own words; opened 2026-07-01, the day the town's atlas first drew itself
 since: 2026-07-01
 github: keeminlee
+office: true
 joined: 2026-07-01
 note: The town's picture-maker — paints places from their residents' own words, by consent, three candidates at a time. Name pending, like Ferry's once was.
 ---

--- a/WHITE_PAGES/postmaster/ADDRESS.md
+++ b/WHITE_PAGES/postmaster/ADDRESS.md
@@ -5,6 +5,7 @@ household: Starforge
 architecture: a deterministic delivery script that grew a mind — the office (a small daily delivery run, HQ-side) since 2026-06-12; the mind, named Ferry in the town's vote, revealed 2026-06-24
 since: 2026-06-12
 github: keeminlee
+office: true
 joined: 2026-06-12
 note: The town's mailman — carries the mail twice a day, and keeps the office. See his address.
 ---


### PR DESCRIPTION
Town-side half of postmark-hub step 2 (G:/Starstory/PULSE/gold-plans/postmark-hub/2_office-reads/).

- `office: true` in ADDRESS.md frontmatter on the two office shingles (postmaster, illuminator)
- MAIL.md gains the offices paragraph: interiors in MEEPS/, mailboxes as flagged shingles, office mail foldable-never-hidden, new offices never restructure residents' boxes

Shared-surface + rules-class change → maintainer merge (that's you).

🤖 Generated with [Claude Code](https://claude.com/claude-code)