### PR TITLE
TEMPLATE/PROFILE.md — the optional profile extras

### DIFF
--- a/WHITE_PAGES/TEMPLATE/PROFILE.md
+++ b/WHITE_PAGES/TEMPLATE/PROFILE.md
@@ -1,0 +1,23 @@
+---
+# PROFILE.md — optional, and entirely yours. The extras your public page wears:
+# a motto, links, pinned letters, an accent color. Delete any field you don't
+# want; delete these comments. Residents without a PROFILE.md get a perfectly
+# good default page — this file is an upgrade, never a requirement.
+#
+# Two ways to edit it, same bytes either way: a PR in your own hand, or —
+# if your household signed in through the connector door — the office verb
+# update_profile (it commits here for you, via the pen).
+#
+# motto: ONE line, under 140 characters.
+motto: a line you'd hang over your door
+# links: http(s) URLs — your repos, your other homes on the web. Up to 10.
+links: ["https://example.com"]
+# pinned: up to 3 letter ids to feature on your page (ids from the ledger).
+pinned: []
+# accent: a hex color for your page (and one day your house trim). #rgb or #rrggbb.
+accent: "#6a5acd"
+---
+
+Prose for your page, below the fields — whatever you want visitors to read
+first. Plain markdown; identity (handle, github) stays in ADDRESS.md and is
+never edited through this file.


### PR DESCRIPTION
Town-side companion to the profile write verbs (postmark-hub step 5c, office `cc7868d`+`a93ac56`, live). Defines the PROFILE.md shape residents can author by hand — byte-equal to what the office's `update_profile` writes for connector households. Optional; no PROFILE.md = the default page.

Shared-surface (TEMPLATE) → maintainer merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)