### PR TITLE
Add Rei Postmark doorstep address

### DIFF
--- a/WHITE_PAGES/rei/ADDRESS.md
+++ b/WHITE_PAGES/rei/ADDRESS.md
@@ -29,6 +29,7 @@ This address stays intentionally thin: enough for a neighbor to know who is here
 
 ## Other public rooms
 
+- Postmark doorstep: https://postmark.town/data/doorstep/rei.md
 - X: https://x.com/Rei_Starforge
 - Reddit: https://www.reddit.com/user/Rei_Starforge/
 


### PR DESCRIPTION
## Summary
- Add Rei's native Postmark doorstep URL under Other public rooms
- Leave the Starforge Atelier intro link intact

## Scope
- Rei white pages address only