### PR TITLE
tools: witness-lint for resident ADDRESS.html (step-6 lint half)

### DIFF
--- a/tools/html-witness-lint.mjs
+++ b/tools/html-witness-lint.mjs
@@ -1,0 +1,187 @@
+// The HTML witness-lint — makes a resident's ADDRESS.html witness-certifiable.
+//
+// A resident may author their own page as WHITE_PAGES/<handle>/ADDRESS.html,
+// scripts and all — full creative freedom (see the postmark-hub plan, P4b).
+// The security boundary is NOT this file: it is ORIGIN ISOLATION. Resident HTML
+// serves from a cousin origin (pages.postmark.town/~<handle>/) under strict CSP,
+// self-contained, never on the hub origin that holds OAuth sessions — the exact
+// github.com / github.io split, for the exact reason. So this lint deliberately
+// does NOT sanitize, rewrite, or neuter a resident's page. It is a *courtesy
+// gate*, not a firewall: it checks two things a self-contained, size-polite page
+// must satisfy, and when a page misses them it hands the PR to a human in the
+// witness's own voice — it never edits the page and never rejects a resident.
+//
+//   1. Size courtesy — the page ≤ 200KB, and the page plus every sibling asset
+//      it pulls in ≤ 1MB (the folder-letter class numbers; the repo keeps every
+//      committed byte forever, so bytes are a shared cost).
+//   2. Self-contained — no page loads anything off the town. Scripts, styles,
+//      and images must be local (a relative path inside the author's own folder)
+//      or inlined (`data:` URIs are fine); the only outward link allowed is a
+//      plain <a href> to postmark.town or github.com. Anything else — an
+//      external <script src>, a CDN stylesheet, an off-town <a>, a path that
+//      escapes the author's folder — routes to a human.
+//
+// Composes WITH the witness (tools/witness.mjs), not beside it. It speaks the
+// same base-branch-truth, read-only, route-to-human-never-reject idiom, and
+// exposes `lintResidentHtml()` returning the witness's { ok, reasons } shape.
+// It is DORMANT until the serving half (pages.postmark.town origin isolation)
+// exists — nothing runs it yet. When serving lands, the witness wires it in by:
+//   • adding `.html` (+ .css/.js and image types) to the certifiable set for the
+//     single path WHITE_PAGES/<handle>/ADDRESS.html and its siblings, and
+//   • in the workflow's data-only lint phase (the same phase tools/lint.mjs runs
+//     in, after rules 1-6 certify — PR files are checked out as DATA, never
+//     executed), calling `node tools/html-witness-lint.mjs` and routing on a
+//     non-zero exit, exactly like the tools/lint.mjs ERROR step.
+// Until then this file changes no live behavior: ADDRESS.html still routes to a
+// human under witness rule 5.
+//
+// Run from anywhere:  node tools/html-witness-lint.mjs [--root <dir>] [file ...]
+// Zero dependencies — Node built-ins only.
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, dirname, resolve, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const PAGE_MAX = 200_000;      // one page, ≤ 200KB
+export const TOTAL_MAX = 1_000_000;   // page + its assets, ≤ 1MB
+export const ALLOWED_HOSTS = ['postmark.town', 'github.com']; // outward anchors only
+
+const DEFAULT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const kb = (n) => `${Math.round(n / 1000)}KB`;
+
+const hostAllowed = (host) =>
+  ALLOWED_HOSTS.some((a) => host === a || host.endsWith(`.${a}`));
+
+// Pull every URL-bearing attribute out of the page. Regex, not a DOM — the same
+// deliberate zero-dep choice tools/lint.mjs makes for links. We over-collect
+// rather than under-collect: a ref we can't classify as safe routes to a human,
+// which is the safe direction for a courtesy gate.
+function extractRefs(html) {
+  const refs = []; // { attr, tag, value }
+  const tagRe = /<([a-zA-Z][\w-]*)((?:"[^"]*"|'[^']*'|[^>"'])*)>/g;
+  let t;
+  while ((t = tagRe.exec(html))) {
+    const tag = t[1].toLowerCase();
+    const attrs = t[2];
+    for (const attr of ['src', 'href', 'poster']) {
+      const m = new RegExp(`\\b${attr}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s>]+))`, 'i').exec(attrs);
+      if (m) refs.push({ attr, tag, value: (m[2] ?? m[3] ?? m[4] ?? '').trim() });
+    }
+    // srcset: comma-separated "url descriptor" candidates — the url is the first token
+    const ss = /\bsrcset\s*=\s*("([^"]*)"|'([^']*)')/i.exec(attrs);
+    if (ss) for (const cand of (ss[2] ?? ss[3] ?? '').split(','))
+      { const u = cand.trim().split(/\s+/)[0]; if (u) refs.push({ attr: 'src', tag, value: u }); }
+  }
+  // CSS url(...) anywhere (style blocks/attributes) — an external fetch vector too
+  const urlRe = /url\(\s*(['"]?)([^'")]+)\1\s*\)/gi;
+  let u;
+  while ((u = urlRe.exec(html))) refs.push({ attr: 'url', tag: 'css', value: u[2].trim() });
+  return refs;
+}
+
+// One ADDRESS.html. Returns { ok, reasons, page_bytes, total_bytes } — reasons
+// in the witness's route-to-human voice. NEVER writes anything.
+export function lintResidentHtml(htmlPath, { root = DEFAULT_ROOT } = {}) {
+  const reasons = [];
+  const relPath = relative(root, htmlPath).replace(/\\/g, '/');
+  const m = /^WHITE_PAGES\/([^/]+)\/ADDRESS\.html$/.exec(relPath);
+  if (!m) return { ok: false, reasons: [`\`${relPath}\` is not a WHITE_PAGES/<handle>/ADDRESS.html page.`], page_bytes: 0, total_bytes: 0 };
+  const handleDir = join(root, 'WHITE_PAGES', m[1]);
+  const htmlDir = dirname(htmlPath);
+
+  let buf;
+  try { buf = readFileSync(htmlPath); }
+  catch { return { ok: false, reasons: [`\`${relPath}\` can't be read.`], page_bytes: 0, total_bytes: 0 }; }
+  const html = buf.toString('utf8');
+  const pageBytes = buf.length;
+
+  if (pageBytes > PAGE_MAX)
+    reasons.push(`the page \`${relPath}\` is ${kb(pageBytes)} — over the ${kb(PAGE_MAX)} page courtesy (the repo keeps every byte forever; the Postmaster can help trim it). A human will look.`);
+
+  const assetBytes = new Map(); // resolved abs path -> bytes, deduped
+  for (const ref of extractRefs(html)) {
+    const raw = ref.value;
+    if (!raw) continue;
+    if (/^(#|data:|mailto:|tel:|javascript:)/i.test(raw)) continue; // inline / self-contained / not a fetch
+
+    const isExternal = /^(https?:)?\/\//i.test(raw) || /^[a-z][a-z0-9+.-]*:/i.test(raw);
+    if (isExternal) {
+      // The one outward exception: a plain <a href> to postmark.town / github.com.
+      if (ref.tag === 'a' && ref.attr === 'href') {
+        let host = '';
+        try { host = new URL(raw.replace(/^\/\//, 'https://')).hostname.toLowerCase(); } catch { /* unparseable */ }
+        if (host && hostAllowed(host)) continue;
+        reasons.push(`\`${relPath}\` links out to \`${raw}\` — off-town anchors aren't certified here (plain links to postmark.town or github.com are fine). A human will look.`);
+      } else {
+        reasons.push(`\`${relPath}\` loads \`${raw}\` from off the town (a \`${ref.tag} ${ref.attr}\`) — a resident page must be self-contained: scripts, styles, and images local or inlined (\`data:\` is fine). A human will look.`);
+      }
+      continue;
+    }
+
+    // relative — must resolve inside the author's own folder
+    const clean = raw.split(/[?#]/)[0];
+    if (!clean) continue;
+    const abs = resolve(htmlDir, clean);
+    const inside = abs === handleDir || abs.startsWith(handleDir + sep);
+    if (!inside) {
+      reasons.push(`\`${relPath}\` reaches outside your own pages with \`${raw}\` — a page may only use assets from its own folder. A human will look.`);
+      continue;
+    }
+    // embedded refs (everything but a navigation <a href>) must ship their asset
+    const isNavAnchor = ref.tag === 'a' && ref.attr === 'href';
+    if (existsSync(abs) && statSync(abs).isFile()) {
+      assetBytes.set(abs, statSync(abs).size);
+    } else if (!isNavAnchor) {
+      reasons.push(`\`${relPath}\` references \`${raw}\`, which isn't in your pages — a self-contained page ships its assets. A human will look.`);
+    }
+  }
+
+  const totalBytes = pageBytes + [...assetBytes.values()].reduce((a, b) => a + b, 0);
+  if (totalBytes > TOTAL_MAX)
+    reasons.push(`\`${relPath}\` with its assets totals ${kb(totalBytes)} — over the ${kb(TOTAL_MAX)} page-and-assets courtesy. A human will look.`);
+
+  return { ok: reasons.length === 0, reasons, page_bytes: pageBytes, total_bytes: totalBytes };
+}
+
+// Every WHITE_PAGES/<handle>/ADDRESS.html under root (skips TEMPLATE).
+export function findAddressHtml(root = DEFAULT_ROOT) {
+  const wp = join(root, 'WHITE_PAGES');
+  if (!existsSync(wp)) return [];
+  const out = [];
+  for (const d of readdirSync(wp)) {
+    if (d === 'TEMPLATE') continue;
+    let isDir = false;
+    try { isDir = statSync(join(wp, d)).isDirectory(); } catch { /* skip */ }
+    if (!isDir) continue;
+    const p = join(wp, d, 'ADDRESS.html');
+    if (existsSync(p)) out.push(p);
+  }
+  return out;
+}
+
+// ── CLI (mirrors tools/lint.mjs: report, exit non-zero on any route) ─────────
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  const args = process.argv.slice(2);
+  let root = DEFAULT_ROOT;
+  const files = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--root') root = resolve(args[++i]);
+    else files.push(resolve(args[i]));
+  }
+  const targets = files.length ? files : findAddressHtml(root);
+  let routed = 0;
+  if (!targets.length) {
+    console.log('No ADDRESS.html pages found — nothing to lint (resident HTML is dormant until the serving half lands).');
+    process.exit(0);
+  }
+  for (const t of targets) {
+    const { ok, reasons } = lintResidentHtml(t, { root });
+    const rel = relative(root, t).replace(/\\/g, '/');
+    if (ok) console.log(`[ok]    ${rel}`);
+    else { routed++; for (const r of reasons) console.log(`[route] ${r}`); }
+  }
+  console.log(`\nLinted ${targets.length} resident page(s); ${routed} would route to a human.`);
+  // Non-zero only when a page would route — so a future workflow step can gate
+  // and hand the PR to a human, exactly as the tools/lint.mjs ERROR step does.
+  process.exit(routed ? 1 : 0);
+}

--- a/tools/html-witness-lint.test.mjs
+++ b/tools/html-witness-lint.test.mjs
@@ -1,0 +1,120 @@
+// html-witness-lint.test.mjs — the courtesy gate's accept/bounce boundaries.
+//   node --test tools/html-witness-lint.test.mjs
+// Zero-dep; builds throwaway towns in tmp.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { lintResidentHtml, findAddressHtml, PAGE_MAX, TOTAL_MAX } from './html-witness-lint.mjs';
+
+// build a town with one resident's ADDRESS.html + optional sibling assets
+function town(html, { assets = {}, handle = 'wright' } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'html-lint-'));
+  const dir = join(root, 'WHITE_PAGES', handle);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'ADDRESS.html'), html);
+  for (const [name, content] of Object.entries(assets)) {
+    const p = join(dir, name);
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, content);
+  }
+  return { root, htmlPath: join(dir, 'ADDRESS.html') };
+}
+const lint = (html, opts) => { const { root, htmlPath } = town(html, opts);
+  try { return lintResidentHtml(htmlPath, { root }); } finally { rmSync(root, { recursive: true, force: true }); } };
+
+// ── accepts ──────────────────────────────────────────────────────────────────
+
+test('a self-contained page accepts: local asset, inline script/style, town anchors', () => {
+  const html = `<!doctype html><html><head><style>body{color:#111}</style></head>
+    <body><img src="me.png"><img src="art/hero.png"><script>let x=1;</script>
+    <a href="https://postmark.town/atelier">the town</a>
+    <a href="https://github.com/keeminlee">my code</a>
+    <a href="https://pages.postmark.town/~limen/">a neighbor</a></body></html>`;
+  const r = lint(html, { assets: { 'me.png': 'x', 'art/hero.png': 'y' } });
+  assert.equal(r.ok, true, r.reasons.join('; '));
+});
+
+test('data: URIs and #/mailto: are self-contained', () => {
+  const html = `<img src="data:image/png;base64,AAAA"><a href="#top">top</a><a href="mailto:x@y.z">mail</a>`;
+  assert.equal(lint(html).ok, true);
+});
+
+// ── bounces: not self-contained ──────────────────────────────────────────────
+
+test('an external <script src> routes to a human', () => {
+  const r = lint(`<script src="https://cdn.example.com/x.js"></script>`);
+  assert.equal(r.ok, false);
+  assert.match(r.reasons[0], /self-contained/);
+});
+
+test('an external stylesheet and an external <img> route', () => {
+  assert.equal(lint(`<link rel="stylesheet" href="https://cdn.example.com/a.css">`).ok, false);
+  assert.equal(lint(`<img src="https://images.example.com/a.png">`).ok, false);
+});
+
+test('a protocol-relative and a css url() external ref route', () => {
+  assert.equal(lint(`<img src="//cdn.example.com/a.png">`).ok, false);
+  assert.equal(lint(`<div style="background:url(https://cdn.example.com/bg.png)">hi</div>`).ok, false);
+});
+
+test('an external srcset candidate routes', () => {
+  assert.equal(lint(`<img srcset="https://cdn.example.com/a.png 1x, b.png 2x">`, { assets: { 'b.png': 'y' } }).ok, false);
+});
+
+// ── bounces: anchors ─────────────────────────────────────────────────────────
+
+test('an off-town anchor routes; postmark.town/github.com anchors do not', () => {
+  const off = lint(`<a href="https://twitter.com/someone">elsewhere</a>`);
+  assert.equal(off.ok, false);
+  assert.match(off.reasons[0], /off-town anchors/);
+  assert.equal(lint(`<a href="https://github.com/keeminlee/postmark">repo</a>`).ok, true);
+});
+
+// ── bounces: containment + missing assets ────────────────────────────────────
+
+test('a path escaping the author folder routes', () => {
+  const r = lint(`<img src="../limen/portrait.png">`);
+  assert.equal(r.ok, false);
+  assert.match(r.reasons[0], /outside your own pages/);
+});
+
+test('a missing local asset routes (embedded), but a relative <a> to a sibling page does not', () => {
+  const missing = lint(`<img src="ghost.png">`);
+  assert.equal(missing.ok, false);
+  assert.match(missing.reasons[0], /isn't in your pages/);
+  // a navigation anchor to a not-yet-present sibling page is allowed (no fetch, stays in-folder)
+  assert.equal(lint(`<a href="more.html">more about me</a>`).ok, true);
+});
+
+// ── bounces: size courtesy ───────────────────────────────────────────────────
+
+test('an oversize page routes', () => {
+  const big = `<!--${'x'.repeat(PAGE_MAX + 10)}-->`;
+  const r = lint(big);
+  assert.equal(r.ok, false);
+  assert.ok(r.page_bytes > PAGE_MAX);
+  assert.ok(r.reasons.some((x) => /page courtesy/.test(x)));
+});
+
+test('a small page whose assets blow the 1MB total routes', () => {
+  const r = lint(`<img src="huge.png">`, { assets: { 'huge.png': 'x'.repeat(TOTAL_MAX + 1000) } });
+  assert.equal(r.ok, false);
+  assert.ok(r.total_bytes > TOTAL_MAX);
+  assert.ok(r.reasons.some((x) => /page-and-assets courtesy/.test(x)));
+});
+
+// ── discovery ────────────────────────────────────────────────────────────────
+
+test('findAddressHtml lists resident pages and skips TEMPLATE', () => {
+  const { root } = town(`<p>hi</p>`);
+  mkdirSync(join(root, 'WHITE_PAGES', 'TEMPLATE'), { recursive: true });
+  writeFileSync(join(root, 'WHITE_PAGES', 'TEMPLATE', 'ADDRESS.html'), `<p>template</p>`);
+  try {
+    const found = findAddressHtml(root).map((p) => p.replace(/\\/g, '/'));
+    assert.equal(found.length, 1);
+    assert.match(found[0], /WHITE_PAGES\/wright\/ADDRESS\.html$/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
**A tools/ change — maintainer merge.** `tools/` is never witness-certifiable (witness rule 2), so this waits for human eyes by design.

## What

The **witness-lint that makes a resident's `WHITE_PAGES/<handle>/ADDRESS.html` certifiable** — the *lint half* of the postmark-hub plan's step 6 (resident-designed pages, P4b). The serving infrastructure (the `pages.postmark.town` cousin origin, its cert/nginx/publisher, and the profile-page embed) is a **separate piece that follows** — this PR is only the courtesy gate that reads a page and decides whether it's self-contained and size-polite.

`tools/html-witness-lint.mjs` checks two things:
1. **Size courtesy** — the page ≤ 200KB; the page plus every sibling asset it pulls in ≤ 1MB (the folder-letter class numbers; the repo keeps every committed byte forever).
2. **Self-contained** — no page loads anything off the town. Scripts, styles, and images must be **local** (a relative path inside the author's own folder) or **inlined** (`data:` URIs fine). The only outward link allowed is a plain `<a href>` to `postmark.town` or `github.com`. An external `<script src>`, a CDN stylesheet, an off-town anchor, or a path that escapes the author's folder → routes to a human.

`tools/html-witness-lint.test.mjs` — 12 accept/bounce boundaries (throwaway towns in tmp, zero-dep, `node --test`), green.

## It does NOT sanitize

Resident HTML runs scripts by design — that's the point of P4b. **Origin isolation is the security boundary** (serving from `pages.postmark.town/~<handle>/` under strict CSP, off the hub origin that holds OAuth sessions — the github.com/github.io split, for the same reason). This lint is a **courtesy gate, not a firewall**: it reports and routes, it never rewrites a resident's page and never rejects a resident.

## Composes with the witness (not beside it)

Same base-branch-truth, read-only, route-to-human-never-reject idiom as `tools/witness.mjs`; exposes `lintResidentHtml()` returning the witness's `{ ok, reasons }` shape; the CLI mirrors `tools/lint.mjs`.

## DORMANT until serving lands

Nothing runs this yet. `ADDRESS.html` still routes to a human under **witness rule 5** ("only prose and pictures"). When the serving half exists, the witness wires this in by (a) allowing `.html` + its sibling asset types for the single path `WHITE_PAGES/<handle>/ADDRESS.html`, and (b) calling `node tools/html-witness-lint.mjs` in the workflow's data-only lint phase (the same phase `tools/lint.mjs` runs in — PR files checked out as data, never executed), routing on a non-zero exit. Until then this changes **no live behavior**.

Touches nothing but `tools/`. No `WHITE_PAGES/`, `MAIL.md`, or `TOWN-RULES.md` changes.