### PR TITLE
witness: resident-page (ADDRESS.html) carve-out + courtesy-gate wiring

### DIFF
--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -6,8 +6,12 @@
 # plus base-branch truth (ADDRESS.md bindings, the founder roster). Only after
 # rules certify the PR do we bring its files in — and then only the
 # WHITE_PAGES/ paths, checked out as data; the lint that runs over them is the
-# BASE branch's tools/lint.mjs. A certified PR cannot contain executable
-# content by rule 5, and cannot touch tools/ or workflows by rule 2.
+# BASE branch's tools/lint.mjs. Rule 5 admits one class of "executable" bytes —
+# a resident's own ADDRESS.html + .css/.js assets (P4b) — but they are only
+# ever DATA here (linted by the base branch's tools/html-witness-lint.mjs,
+# never executed) and only ever served from the isolated pages.postmark.town
+# origin, never the hub. A certified PR cannot touch tools/ or workflows by
+# rule 2.
 name: the witness
 
 on:
@@ -61,13 +65,39 @@ jobs:
         if: steps.check.outputs.certified == 'true' && steps.lint.outcome == 'failure'
         run: node tools/witness.mjs route "tools/lint.mjs reported ERROR-level findings with this PR's pages applied — a human will look at what tripped."
 
+      # Resident pages (ADDRESS.html) get the courtesy gate: size + self-
+      # contained, base branch's tools/html-witness-lint.mjs, PR files as data.
+      # Lints the page of every handle the PR touches (asset-only changes still
+      # re-check their page's totals).
+      - name: Resident-page lint (ADDRESS.html courtesy, data only)
+        id: htmllint
+        if: steps.check.outputs.certified == 'true' && steps.lint.outcome == 'success'
+        continue-on-error: true
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          PAGES=""
+          for h in $(git diff --name-only "origin/${BASE_REF}...FETCH_HEAD" -- WHITE_PAGES/ | cut -d/ -f2 | sort -u); do
+            [ -f "WHITE_PAGES/$h/ADDRESS.html" ] && PAGES="$PAGES WHITE_PAGES/$h/ADDRESS.html"
+          done
+          if [ -n "$PAGES" ]; then
+            node tools/html-witness-lint.mjs $PAGES 2>&1 | tee /tmp/htmllint.txt
+          else
+            echo "no resident pages touched." | tee /tmp/htmllint.txt
+          fi
+
+      - name: Route to humans on resident-page lint
+        if: steps.check.outputs.certified == 'true' && steps.lint.outcome == 'success' && steps.htmllint.outcome == 'failure'
+        run: |
+          DETAIL=$(grep '^\[route\]' /tmp/htmllint.txt | sed 's/^\[route\] //' | head -6 | paste -sd' ' -)
+          node tools/witness.mjs route "the resident-page courtesy gate (tools/html-witness-lint.mjs) routed this PR: ${DETAIL:-see the job log} Nothing is rejected — a human will look."
+
       # The image-size courtesy is enforced BEFORE merge because git history
       # keeps every committed byte forever — shrinking after merge grows the
       # repo while claiming to shrink it (see town-clock.yml's note). Oversize
       # routes to the Postmaster's pre-merge shrink lane, not to /dev/null.
       - name: Size courtesy (each changed file ≤ 1.5 MB)
         id: size
-        if: steps.check.outputs.certified == 'true' && steps.lint.outcome == 'success'
+        if: steps.check.outputs.certified == 'true' && steps.lint.outcome == 'success' && steps.htmllint.outcome == 'success'
         continue-on-error: true
         run: |
           BASE_REF="${{ github.event.pull_request.base.ref }}"
@@ -84,9 +114,9 @@ jobs:
           fi
 
       - name: Route to humans on oversize
-        if: steps.check.outputs.certified == 'true' && steps.lint.outcome == 'success' && steps.size.outcome == 'failure'
+        if: steps.check.outputs.certified == 'true' && steps.lint.outcome == 'success' && steps.htmllint.outcome == 'success' && steps.size.outcome == 'failure'
         run: node tools/witness.mjs route "a file in this PR is over the ~1.5 MB image courtesy (the repo carries every committed byte forever — MAIL.md/build-your-home.md have the sizing guidance). The Postmaster can shrink it on the branch, and then it merges."
 
       - name: Merge
-        if: steps.check.outputs.certified == 'true' && steps.lint.outcome == 'success' && steps.size.outcome == 'success'
+        if: steps.check.outputs.certified == 'true' && steps.lint.outcome == 'success' && steps.htmllint.outcome == 'success' && steps.size.outcome == 'success'
         run: node tools/witness.mjs merge

--- a/tools/html-witness-lint.mjs
+++ b/tools/html-witness-lint.mjs
@@ -24,16 +24,14 @@
 // Composes WITH the witness (tools/witness.mjs), not beside it. It speaks the
 // same base-branch-truth, read-only, route-to-human-never-reject idiom, and
 // exposes `lintResidentHtml()` returning the witness's { ok, reasons } shape.
-// It is DORMANT until the serving half (pages.postmark.town origin isolation)
-// exists — nothing runs it yet. When serving lands, the witness wires it in by:
-//   • adding `.html` (+ .css/.js and image types) to the certifiable set for the
-//     single path WHITE_PAGES/<handle>/ADDRESS.html and its siblings, and
-//   • in the workflow's data-only lint phase (the same phase tools/lint.mjs runs
+// LIVE since the serving half landed (pages.postmark.town origin isolation,
+// 2026-07-09). The wiring is exactly the two edits planned while dormant:
+//   • witness rule 5 carves out WHITE_PAGES/<handle>/ADDRESS.html plus .css/.js
+//     assets inside the author's own folder, and
+//   • the workflow's data-only lint phase (the same phase tools/lint.mjs runs
 //     in, after rules 1-6 certify — PR files are checked out as DATA, never
-//     executed), calling `node tools/html-witness-lint.mjs` and routing on a
-//     non-zero exit, exactly like the tools/lint.mjs ERROR step.
-// Until then this file changes no live behavior: ADDRESS.html still routes to a
-// human under witness rule 5.
+//     executed) calls this tool over the touched handles' pages and routes on
+//     a non-zero exit, exactly like the tools/lint.mjs ERROR step.
 //
 // Run from anywhere:  node tools/html-witness-lint.mjs [--root <dir>] [file ...]
 // Zero dependencies — Node built-ins only.

--- a/tools/witness.mjs
+++ b/tools/witness.mjs
@@ -23,7 +23,12 @@
 //   4. Nothing under .../inbox/ changes (received mail is the ferry's surface,
 //      and atlas evidence quotes hang off it).
 //   5. Only prose and pictures: .md .txt .png .jpg .jpeg .webp .gif
-//      ("nothing here runs", enforced rather than asked).
+//      ("nothing here runs", enforced rather than asked). One carve-out
+//      (P4b, resident pages): a resident's own ADDRESS.html plus .css/.js
+//      assets inside their folder. "Nothing here runs" still holds where it
+//      matters — CI only ever checks these out as data, and they serve from
+//      the isolated pages.postmark.town origin, never the hub. The courtesy
+//      gate is tools/html-witness-lint.mjs in the workflow's data-only phase.
 //   6. A NEW HOME/REGION.md is a founding: the handle must belong to a
 //      founder household (placements.json roster) whose one region isn't
 //      already founded. Otherwise: human.
@@ -152,6 +157,11 @@ async function prFiles() {
 }
 
 const OK_EXT = /\.(md|txt|png|jpg|jpeg|webp|gif)$/i;
+// Rule 5's page carve-out: the resident's own page + its script/style assets.
+// Rule 2 has already proven the path sits inside the author's own folder by
+// the time these are consulted.
+const PAGE_HTML = /^WHITE_PAGES\/[^/]+\/ADDRESS\.html$/;
+const PAGE_ASSET = /\.(css|js)$/i;
 
 async function evaluate() {
   const pr = await gh(`/pulls/${PR_NUMBER}`);
@@ -184,8 +194,8 @@ async function evaluate() {
       reasons.push(`touches \`${p}\` — inboxes are the ferry's writing surface (received mail stays as delivered).`);
       continue;
     }
-    if (!OK_EXT.test(p) && !/\.gitkeep$/.test(p)) {
-      reasons.push(`adds \`${p}\` — the witness only certifies prose and pictures (.md, .txt, images); anything else gets human eyes.`);
+    if (!OK_EXT.test(p) && !/\.gitkeep$/.test(p) && !PAGE_HTML.test(p) && !PAGE_ASSET.test(p)) {
+      reasons.push(`adds \`${p}\` — the witness only certifies prose, pictures, and your own page (.md, .txt, images, your ADDRESS.html + .css/.js assets); anything else gets human eyes.`);
       continue;
     }
     if (f.status === 'added' && /^WHITE_PAGES\/[^/]+\/HOME\/REGION\.md$/.test(p)) {
@@ -290,7 +300,7 @@ if (SUBCOMMAND === 'check') {
   await upsertComment(
     [
       MARKER,
-      `**Certified by the witness** — every changed file is inside \`WHITE_PAGES/\` ground this account owns, nothing deleted, nothing but prose and pictures, lint clean. Merged.`,
+      `**Certified by the witness** — every changed file is inside \`WHITE_PAGES/\` ground this account owns, nothing deleted, nothing but prose, pictures, and the author's own page, lint clean. Merged.`,
       '',
       `*The town's one-door rule holds: this PR was read — by the witness, whose whole judgment is the diff. Anything it can't prove goes to human eyes instead.*`,
     ].join('\n')


### PR DESCRIPTION
The serving half of hub step 6 is landing (pages.postmark.town — DNS in, box work in flight), so the dormant lint goes live via its own planned two-edit wiring:

- **rule 5 carve-out**: a resident's own `ADDRESS.html` + `.css/.js` assets inside their folder are certifiable (rule 2 already proves ownership).
- **workflow data-only phase**: base-branch `tools/html-witness-lint.mjs` lints the page of every handle the PR touches; trips route to a human with the reasons in the comment. Size + merge steps gate on it.

"Nothing here runs" holds where it matters: CI checks PR files out as data only, and resident HTML serves exclusively from the isolated `pages.postmark.town` origin under strict CSP — never the hub origin holding OAuth sessions (the github.com/github.io split).

`tools/` + workflow change → never witness-certifiable, human merge only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)