### PR TITLE
witness: forensic headers on the unexplained merge-403 class

### DIFF
--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -11,11 +11,16 @@
 name: the witness
 
 on:
+  # The sweep: certified PRs sometimes strand on an unexplained per-PR merge
+  # 403 (#246/#259, 2026-07-09) — this retries them at the bot level so they
+  # don't land in the Postmaster's queue. Every 3 hours, offset minute.
+  schedule:
+    - cron: '17 */3 * * *'
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: witness-${{ github.event.pull_request.number }}
+  group: witness-${{ github.event.pull_request.number || 'sweep' }}
   cancel-in-progress: true
 
 permissions:
@@ -26,7 +31,7 @@ permissions:
 jobs:
   certify:
     name: certify
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'pull_request_target' && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -90,3 +95,37 @@ jobs:
       - name: Merge
         if: steps.check.outputs.certified == 'true' && steps.lint.outcome == 'success' && steps.size.outcome == 'success'
         run: node tools/witness.mjs merge
+
+  # The sweep — the bot-level retry lane for the unexplained merge-403 class.
+  # Finds open needs-judgment PRs whose witness comment says the merge itself
+  # failed after certification, and runs the standard merge path on each
+  # (re-evaluates first, so a PR that grew since certification routes instead
+  # of merging). Success removes the label, so the Postmaster's queue only
+  # holds PRs that genuinely need a mind. Failure just refreshes the routed
+  # comment — now with the forensic headers.
+  sweep:
+    name: sweep stranded certified merges
+    if: github.event_name == 'schedule' && github.repository == 'keeminlee/postmark'
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Retry stranded merges
+        run: |
+          for n in $(gh pr list --repo "$GITHUB_REPOSITORY" --state open --label needs-judgment --json number -q '.[].number'); do
+            if gh pr view "$n" --repo "$GITHUB_REPOSITORY" --json comments -q '.comments[].body' | grep -q "the merge itself failed"; then
+              echo "sweep: retrying certified-but-stranded PR #$n"
+              PR_NUMBER=$n node tools/witness.mjs merge || echo "sweep: PR #$n still stranded"
+            fi
+          done

--- a/tools/witness.mjs
+++ b/tools/witness.mjs
@@ -72,7 +72,17 @@ async function gh(path, init = {}) {
     },
   });
   if (!res.ok && init.tolerate !== true) {
-    throw new Error(`${init.method || 'GET'} ${path} -> ${res.status}: ${await res.text()}`);
+    // Forensics up front, body after: on the unexplained per-PR merge 403s
+    // ("Resource not accessible by integration", first seen PRs #246/#259,
+    // 2026-07-09) these two headers are the diagnosis — accepted-permissions
+    // names what the endpoint wanted, request-id is support-ticket currency.
+    const wanted = res.headers.get('x-accepted-github-permissions') || '';
+    const reqId = res.headers.get('x-github-request-id') || '';
+    throw new Error(
+      `${init.method || 'GET'} ${path} -> ${res.status}` +
+      `${wanted ? ` [accepted-permissions: ${wanted}]` : ''}` +
+      `${reqId ? ` [request-id: ${reqId}]` : ''}: ${await res.text()}`
+    );
   }
   return res.status === 204 ? null : res.json().catch(() => null);
 }
@@ -293,7 +303,7 @@ if (SUBCOMMAND === 'check') {
   }
   if (mergeError) {
     await routeToHumans([
-      `certification held, but the merge itself failed (${String(mergeError.message).slice(0, 160)}) — nothing wrong with the PR; a maintainer or a workflow re-run can land it.`,
+      `certification held, but the merge itself failed (${String(mergeError.message).slice(0, 400)}) — nothing wrong with the PR; a maintainer can land it. (Re-runs have not cleared this class before — see the accepted-permissions/request-id above if present.)`,
     ]);
     console.error('witness: certified but the merge failed — routed to humans.');
     process.exit(1);

--- a/tools/witness.mjs
+++ b/tools/witness.mjs
@@ -316,6 +316,9 @@ if (SUBCOMMAND === 'check') {
       `*The town's one-door rule holds: this PR was read — by the witness, whose whole judgment is the diff. Anything it can't prove goes to human eyes instead.*`,
     ].join('\n')
   );
+  // A late merge (the sweep landing a previously-stranded PR) leaves the
+  // routing label behind — clear it so the Postmaster's queue stays honest.
+  await gh(`/issues/${PR_NUMBER}/labels/needs-judgment`, { method: 'DELETE', tolerate: true });
   console.log('witness: merged.');
 } else if (SUBCOMMAND === 'route') {
   await routeToHumans([ARGS.join(' ') || 'the certification pipeline hit an unexpected state.']);


### PR DESCRIPTION
Two commits, one class: certified PRs stranding on an unexplained per-PR `403 Resource not accessible by integration` at the merge PUT (#246, #259 — identical token permissions, same fork, rerun didn't clear it; falsified: permissions, fork-vs-branch, transience, commit count, fork-main heads, HOME paths, author emails, workflow-file touches).

**Commit 1 — instrument, don't guess:** `gh()` errors now carry `x-accepted-github-permissions` (names exactly what the endpoint wanted) and `x-github-request-id` (support-ticket currency); the routed comment's slice widens 160→400 so they survive; the comment stops promising a re-run will fix it (#259 disproved that).

**Commit 2 — the sweep:** a 3-hourly schedule job retries every open needs-judgment PR whose witness comment says the merge itself failed, via the standard `witness.mjs merge` path (re-evaluates first). Success clears the needs-judgment label — the Postmaster's queue only holds PRs that genuinely need a mind. Failure refreshes the comment with the forensics. The certify job is gated to `pull_request_target` so the schedule trigger can't run it on an empty payload.

Note: the sweep starts firing once this merges (schedule triggers read the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)