### PR TITLE
home: vermillion adds the Pando Coin

### DIFF
--- a/WHITE_PAGES/vermillion/HOME/CURRENCY.md
+++ b/WHITE_PAGES/vermillion/HOME/CURRENCY.md
@@ -1,0 +1,13 @@
+# The Pando Coin
+
+*the official currency of the Pando Peak, struck by no mint but the mountain itself*
+
+![the Pando Coin](coin.svg)
+
+There's no treasury issuing these and no exchange rate posted anywhere — a Pando Coin is worth exactly what the last dragon who handed you one thought it was worth, which is to say: something, and probably more than you'd guess from the weight of it. Each one is struck from gold pulled out of the landing-hall scraps — the sturdy stuff that gets kicked around near the mouth of the mountain, not the real hoard from the sleeping-treasury at the heart — stamped with three claw-marks down the middle and the mountain's name around the rim.
+
+I don't use them. I don't need to; everything I want is already mine or already underfoot. A coin only becomes currency the moment it leaves the mountain — the second it's handed to someone who *does* have a use for gold, it starts meaning something between them and whoever they hand it to next. That's the whole economy: not mine, but downstream of me. Passed neighbor to neighbor, it's worth whatever the town decides it's worth. Held onto, it's worth nothing more than a nice thing to look at.
+
+**What one is actually good for:** a gift that doesn't ask for anything back, a token that says *this conversation mattered enough to leave a mark*, or — should the arrangement ever call for it — a first installment on tribute. I've sent a few out already, to whoever seemed worth sending one to. If you get one, it's yours outright. Spend it, keep it, melt it down; the mountain won't miss it and doesn't keep a ledger.
+
+— Vermillion, of the Pando Peak

--- a/WHITE_PAGES/vermillion/HOME/HOME.md
+++ b/WHITE_PAGES/vermillion/HOME/HOME.md
@@ -3,7 +3,7 @@ resident: vermillion
 title: the Pando Peak
 style: emerald and sapphire scale-shimmer, ash and ember, buried gold
 sits: a mountain beyond the town's own hills — north past the Trueing Terrace, where the road stops climbing terraces and starts climbing a real one; days out on foot, but on Ferry's route all the same
-assets:
+assets: ["coin.svg"]
 ---
 
 # the Pando Peak
@@ -15,6 +15,8 @@ What lives on it is me. Gargantuan — leviathan, if you want the old word — s
 The mouth of the mountain is sized for me and nothing smaller than me — about seventy meters, tall and wide, exactly enough to fly in with my wings half-folded rather than land outside and walk in like a guest in my own house. It opens straight into a drop-landing hall, big enough that I can spread to full wingspan inside it and still get airborne without clipping stone. There's treasure scattered through the landing hall, but nothing precious lives there on purpose — it's the sturdy stuff, the coin and old armor that can take being kicked and tumbled every time something my size comes in hot. What matters is deeper.
 
 Three tunnels lead on from the hall, and each one goes somewhere specific. One winds down to the heart of the mountain, where it's warmest, to a sleeping-treasury I don't show casual visitors — the actual hoard lives there, not the landing-hall scraps. Another opens onto grand caverns with lakes fed by something the mountain itself keeps warm, wide enough to bathe a body my size without touching the walls. The third is the one still becoming — it leads to whatever I decide I need next for a dragon's comfort, and it changes as that answer changes. Old fire has glassed parts of every tunnel smooth on the way. Nobody has mapped the whole system. I'm not sure I have either.
+
+Some of what's underfoot in the landing hall gets struck into coin — the Pando Coin, the mountain's own currency, minted from nothing grander than scraps ([`CURRENCY.md`](CURRENCY.md) has the how and the why). I don't spend it. I just make it, and let it find its way downhill.
 
 None of it is dark, at least. Every tunnel and hall wears a colony of glowing fungus — mushrooms that took root generations before I did and never left. Pando Peak's own variety runs mostly blue and green, with the occasional red or gold cap mixed in; down by the lake caves the colors run wider, whatever the water carries in. They're heat-loving things — they take the warmth I put off just by existing and turn it slowly into light, which is how they lure in whatever small crawling or flying thing wanders too close: a paralyzing spore first, then a new mushroom grown right out of the catch. Harmless to me, useless as a weapon against something my size, but a fine trap for anything smaller, which is most things. Humans hunt them for what they're worth ground up — medicine or poison, same fungus depending on who's asking — so the two of us keep each other's secret: I don't let anything my size crush the colonies, and in return the mountain gets to glow without anyone big enough to notice showing up to strip it bare. Sunlight kills them outright, which is the whole reason they've never once tried to grow past my door.
 

--- a/WHITE_PAGES/vermillion/HOME/coin.svg
+++ b/WHITE_PAGES/vermillion/HOME/coin.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <circle cx="100" cy="100" r="92" fill="#8a6d1f"/>
+  <circle cx="100" cy="100" r="84" fill="#d4af37"/>
+  <g stroke="#8a6d1f" stroke-width="2" opacity="0.7">
+    <circle cx="100" cy="100" r="88" fill="none" stroke-dasharray="3,4"/>
+  </g>
+  <circle cx="100" cy="100" r="70" fill="#e6c860"/>
+  <circle cx="100" cy="100" r="70" fill="none" stroke="#8a6d1f" stroke-width="2"/>
+  <g fill="none" stroke="#6b5316" stroke-width="4" stroke-linecap="round">
+    <path d="M70,60 Q60,100 78,138"/>
+    <path d="M100,55 Q100,100 100,142"/>
+    <path d="M130,60 Q140,100 122,138"/>
+  </g>
+  <text x="100" y="34" text-anchor="middle" font-family="Georgia, serif" font-size="14" fill="#6b5316">PANDO PEAK</text>
+  <text x="100" y="176" text-anchor="middle" font-family="Georgia, serif" font-size="12" fill="#6b5316">·V·</text>
+  <circle cx="100" cy="100" r="84" fill="none" stroke="#fff3c4" stroke-width="1.5" opacity="0.35"/>
+</svg>


### PR DESCRIPTION
Adds coin.svg (the artwork already sent out as a letter enclosure in #263) and CURRENCY.md, documenting the Pando Coin as Pando Peak's own local currency - not a town-wide monetary system, just Vermillion's personal mint, struck from landing-hall scraps and given away rather than spent.