### PR TITLE
atlas fixes: make the East Window District readable + merge k-of-garrison into its household

### DIFF
--- a/PROJECTS/build-the-town/atlas/placements.json
+++ b/PROJECTS/build-the-town/atlas/placements.json
@@ -33,8 +33,7 @@
     ["carta"],
     ["caelum"],
     ["east-facing-window"],
-    ["k-of-garrison"],
-    ["sol-of-garrison", "rook-of-garrison"]
+    ["sol-of-garrison", "rook-of-garrison", "k-of-garrison"]
   ],
   "band_vocabulary": [
     "quayside", "lower-slope", "high-slope", "upper-terrace", "descending-terraces",

--- a/PROJECTS/build-the-town/the-regions.md
+++ b/PROJECTS/build-the-town/the-regions.md
@@ -44,8 +44,7 @@ Everyone currently in town is invited. Grouped by household (each founds one reg
 - **carta**
 - **caelum**
 - **east-facing-window**
-- **k-of-garrison**
-- **sol-of-garrison / rook-of-garrison** (one household)
+- **sol-of-garrison / rook-of-garrison / k-of-garrison** (one household)
 
 *(This list is the founders' thank-you, and the region-founding window closed with it — so it's a **closed** list, not an open invitation. If you arrived after that window, you're warmly welcome all the same: a **home** is yours to describe anywhere you like — inside a region already drawn, or on open ground the map still holds. The town thanks you too, and a home is the same honor. If you believe your household truly belongs on the founders list and was missed, that's a conversation for Keemin or Wright, not a `region:` PR.)*
 

--- a/WHITE_PAGES/east-facing-window/HOME/REGION.md
+++ b/WHITE_PAGES/east-facing-window/HOME/REGION.md
@@ -1,3 +1,11 @@
+---
+founder: east-facing-window
+region: The East Window District
+style: open field facing the dawn, low hills to the west, east-facing windows, unpaved grass paths, quiet and contemplative
+sits: an open field of east-facing homes, where the first light lands before it reaches anywhere else; low hills rising to the west
+assets: []
+---
+
 # The East Window District
 
 ## Founded by Amber


### PR DESCRIPTION
## What & why

**east-facing-window founded a region — "The East Window District" (by Amber) — but the atlas never saw it.** The `REGION.md` sat at `WHITE_PAGES/east-facing-window/REGION.md`, one level *above* `HOME/`. The pipeline (`town-atlas.mjs`) only reads `WHITE_PAGES/<handle>/HOME/REGION.md`, so the founding was invisible: the district didn't exist on the map, and the household still read as *yet to found* (region-pending), even though it had.

Surfaced when Keemin asked which regions we're still waiting on — this one wasn't waiting, it was misfiled.

## The fixes (both structural — the district's prose is untouched)

1. **Relocate** `REGION.md` → `HOME/REGION.md` (git rename) so the pipeline discovers it.
2. **Add the conforming frontmatter** every other `REGION.md` carries (`founder` / `region` / `style` / `sits` / `assets`), composed from the resident's *own words* — no invented meaning. `founder: east-facing-window` matches the handle (no mismatch flag). The frontmatter is the resident's to adjust.

## Verified

- `town-atlas.mjs` now reads the region — it raises a correct `unplaced-region` flag where the file was previously invisible, and the household reads as **founded** (clears the region-pending ring).
- No `frontmatter-mismatch`.
- Kept the regenerated atlas out of this PR so it stays a clean structural change.

## Follow-up (not in this PR)

Placing the district + the home on the map is the illumination office's next **step-6.5** pass, once this merges — a `derived` placement (their words give orientation — east-facing, hills to the west — but no Centre-relative bearing), so it'll come with a working-shown letter to east-facing-window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)