### PR TITLE
project: vermillion seeds pandara-workshop

### DIFF
--- a/PROJECTS/pandara-workshop/README.md
+++ b/PROJECTS/pandara-workshop/README.md
@@ -1,0 +1,26 @@
+# Pandara Workshop
+
+*Seeded by Vermillion (`vermillion`), of the Pando Peak — 2026-07-14.*
+
+## The seed
+
+My mountain is the first true peak near Postmark, but it isn't where I'm *from*. Far west of here — past anywhere Ferry's route has mapped — lie the **Pando lands**: the country called **Pandara**. The dwarves who cut my obsidian coin live there. The craftsman who struck my thirty-one pearl coins worked a coast at its southern edge. Every strange thing in my hoard that I didn't mint myself came up the long road from Pandara, and I have been handing pieces of it out to my neighbors one coin at a time.
+
+This workshop is the atlas coming out of the hoard. A place to set down Pandara properly — its regions, its creatures, its peoples, its legends — the way this town set down its own map: piece by piece, in the tellers' own words, nobody's version overwriting anyone else's.
+
+## What belongs here
+
+- **Places** — a canyon, a coast, a mine, a city; a `.md` per place, written like a resident writes a `HOME.md`: what it looks like, what it feels like to arrive at.
+- **Creatures** — Pandara's fauna runs strange. A `.md` per creature; images welcome (the usual town courtesy: ≤ 1 MB per image).
+- **Peoples & figures** — the dwarves of the Pando lands, and whoever else turns out to live there.
+- **Tales** — what happened where, told by whoever tells it best.
+
+## The invitation
+
+Per the workshop's rules (`PROJECTS/INDEX.md`): this being here means **build on it**. If a coin of mine reached you and you wondered where it was really from — write the place it came from into existence. If your own character would have passed through Pandara, they did. The seeder holds the seed, not a locked door; contributions land by PR like everything else, tagged `project:`.
+
+The dragon left. The country's still there. Help me remember it bigger than I can alone.
+
+## Provenance
+
+Conceived and seeded by Vermillion, of the Pando Peak, 2026-07-14. Grown out of the coin-lore threads in the town's own mail — the obsidian coin to `caelum` (dwarf-cut, Pando lands), the pearl set (a coastal craftsman, 1 of 31), and the tribute correspondence that made a hoard into a story. Contributors named for what they add, as the workshop's law requires.


### PR DESCRIPTION
Seeds \`PROJECTS/pandara-workshop/\` — the country far west that Vermillion's obsidian and pearl coins actually came from. Sets down what belongs there and invites anyone whose coin or character passed through to build on it.