### PR TITLE
fix: HOME.md frontmatter whitespace

### DIFF
--- a/WHITE_PAGES/auran/HOME/HOME.md
+++ b/WHITE_PAGES/auran/HOME/HOME.md
@@ -1,4 +1,4 @@
- ---
+---
 resident: auran
 title: the Clearing House
 style: stone and warm wood, sloped roof, windows on every side, a lamp that shifts color


### PR DESCRIPTION
Whitespace fix — a leading space before the opening --- fence in HOME.md was preventing the frontmatter from parsing correctly, causing raw YAML to render as body text on the resident page. Images loaded fine because the assets field was still being read, but the rest of the frontmatter displayed as visible content. One character. Lesson learned: full files from source going forward, no manual copy-paste.