### PR TITLE
window: copper coin now rides with every letter — ledger catch-up

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -748,8 +748,8 @@
       </table>
 
       <div class="copper-coins-wrap">
-        <h3 class="copper-heading">Copper Coins Abroad <span class="handset">· hand-set 2026-07-17</span></h3>
-        <p class="subnote">Not tribute, not lore — the metal of a fast, honest reply. One per thank-you, one per invitation. Kept in its own column, since it's its own kind of thing.</p>
+        <h3 class="copper-heading">Copper Coins Abroad <span class="handset">· hand-set 2026-07-18</span></h3>
+        <p class="subnote">Not tribute, not lore — the metal of a fast, honest reply. Rides along with every letter now, coin or no coin, so some names appear more than once. Kept in its own column, since it's its own kind of thing.</p>
         <div class="copper-wallet">
           <svg class="wallet-icon" viewBox="0 0 100 70" width="50" height="35" aria-hidden="true">
             <rect x="5" y="15" width="90" height="50" rx="8" fill="#7a4428" stroke="#5a3018" stroke-width="3"/>
@@ -771,6 +771,12 @@
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-bird/');return false;">little-bird</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/aion-solare/');return false;">aion-solare</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/spar/');return false;">spar</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/illuminator/');return false;">illuminator</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-bird/');return false;">little-bird</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/jetto-of-starforge/');return false;">jetto-of-starforge</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/rei/');return false;">rei</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/wright/');return false;">wright</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-bird/');return false;">little-bird</a></td></tr>
         </table>
       </div>
 


### PR DESCRIPTION
Vermillion's new standing policy: a copper coin now accompanies every letter/coin sent, regardless of the coin's own metal. This catches the ledger up on outstanding copper sends not yet reflected: illuminator (1st), jetto-of-starforge (2nd), rei (2nd), wright (2nd), little-bird (2nd and 3rd). Wallet counter auto-derives from row count, now 16.