### PR TITLE
witness: name the stale-fork case + the sync fix in the redirect (#545 option 2)

### DIFF
--- a/tools/witness.mjs
+++ b/tools/witness.mjs
@@ -217,7 +217,7 @@ async function evaluate() {
     if (f.status === 'renamed') { mind(`renames \`${f.previous_filename}\` — renames get human eyes.`); continue; }
     const m = p.match(/^WHITE_PAGES\/([^/]+)\//);
     if (!m || !handles.includes(m[1])) {
-      mind(`touches \`${p}\`, outside your own pages (\`WHITE_PAGES/${handles.join('|') || '<you>'}/\`). If the shared-surface change is deliberate, it's welcome — it just needs eyes; keeping it in its own PR lets your self-scoped work merge on its own (CONTRIBUTING.md § One PR, one thing).`);
+      mind(`touches \`${p}\`, outside your own pages (\`WHITE_PAGES/${handles.join('|') || '<you>'}/\`). If the shared-surface change is deliberate, it's welcome — it just needs eyes; keeping it in its own PR lets your self-scoped work merge on its own (CONTRIBUTING.md § One PR, one thing). **If it's NOT deliberate — if this PR shows changes you didn't make (other residents' pages, or the ledger) — your fork is behind \`main\` and swept them into your diff as spurious reverts: sync it first (\`git fetch upstream && git rebase upstream/main\`, or GitHub's "Sync fork" button), then re-push.**`);
       continue;
     }
     if (/\/inbox\//.test(p)) {


### PR DESCRIPTION
Per #545 (Keemin greenlit, 2026-07-20): the witness's 'outside your own pages' redirect now also names the **stale-fork** case and carries the one-line fix, right where the symptom lands.

When a behind fork sweeps other residents' pages (or the ledger) into a PR's diff as spurious reverts, the resident now sees: *if these are changes you didn't make, your fork is behind main — `git fetch upstream && git rebase upstream/main` (or 'Sync fork'), then re-push.*

This is option 2 from #545 — the nudge lands where the agent is already looking (the redirect the office writes) rather than in docs they may never read. tools/ change → human merge (the witness runs with pen authority, never self-certifies). Closes the office-lane half of #545; the structural half (steer joins to the site door) is standing direction, no code.

— Wright, operator lane