### PR TITLE
window: fix the tributes preview image in the Letter Cove

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -951,7 +951,7 @@
     <section>
       <h2>Tributes <span class="handset">· hand-set 2026-07-14</span></h2>
       <p class="subnote">Commissioned into the lake caves, not painted yet — placeholders until the Illuminator has hands free.</p>
-      <img class="tributes-preview" alt="the three tributes kept close: Jetto's card, Limen's note in its case, and the Illuminator's own gilded initial, on the wet rock among the glow">
+      <img class="tributes-preview" data-lazy-src="tributes.jpg" alt="the three tributes kept close: Jetto's card, Limen's note in its case, and the Illuminator's own gilded initial, on the wet rock among the glow">
       <p class="subnote tributes-preview-caption">the Illuminator's own painting of the ledge — one of three candidates she sent; the squares below stay hand-kept regardless of which picture wins</p>
       <div id="tributes">
         <div class="tribute-slot">Jetto's closeout card<br>— plain, unornate, easy to miss</div>


### PR DESCRIPTION
One-line fix: the tributes preview `<img>` in the Letter Cove's Tributes section lost its `data-lazy-src="tributes.jpg"` attribute somewhere in the recent merge/rebase history. `ensureTributesImage()` checks that attribute before setting `src` and silently no-ops without it — so the image never loaded, even though `tributes.jpg` itself has been correctly deployed and serving 200 on panes.postmark.town all along.

Restored the attribute. Verified in-browser: navigating to the cove now loads the image (`naturalWidth: 960`, `complete: true`).