### PR TITLE
stamp-mint: the three tenses — foldMintCount + foldStaked (quest Phase 1)

### DIFF
--- a/STAMPS.md
+++ b/STAMPS.md
@@ -127,6 +127,36 @@ supply only rises, prices drift upward over time, and sellers reprice — a know
 and accepted property. If the town ever wants scarcity back, `BURN` is the other
 reserved line, waiting for its own blessing. Not this one.
 
+## What your stamps add up to — three tenses
+
+One number can't hold three true things at once, so the ledger keeps three. Your
+stamps have a **past, a present, and a pledge**:
+
+- **Minted** — every stamp you have *ever* earned, added up and never taken away.
+  It only rises: spending or staking never lowers it, because it records what you
+  *generated*, not what you happen to hold. This is the town's equity number — the
+  honest measure of the correspondence you've set in motion — and it's **public**,
+  shown on your resident page.
+- **Liquid** — what you can spend or stake **right now**. This is the balance the
+  town has always shown: mints in, spends and stakes out.
+- **Staked** — stamps you have locked in an open vote. Not gone — *pledged*. Every
+  one returns to your liquid balance when the ballot closes.
+
+And the two quantities that fall out of those:
+
+> **assets = liquid + staked** — everything you *hold* today.
+> **minted ≥ assets** — you can't hold more than you ever made (the one exception
+> is a transfer: being *paid* stamps is the only way to hold what you didn't mint).
+
+A quiet consequence worth saying out loud: because liquid is minted-minus-staked,
+**your spendable balance dips while you have an open stake** — and climbs back the
+moment the vote closes and your pledge returns. That dip is staking working, not
+stamps lost; your *minted* number never moves.
+
+All three are pure folds over the same sealed ledger (`foldMintCount`,
+`foldStaked`, `foldBalances` in `tools/stamp-mint.mjs`) — no new stored state,
+recomputable and checkable any time, like every other stamp fact on this page.
+
 ## Zero stamps is fine
 
 **Zero-stamp participation is fully first-class.** A resident with no stamps is a

--- a/tools/stamp-mint.mjs
+++ b/tools/stamp-mint.mjs
@@ -384,6 +384,51 @@ export function foldBalances(entries) {
   return bal;
 }
 
+// ── the three tenses (quest gold Phase 1) ────────────────────────────────────
+// foldBalances above is the LIQUID balance: a stake moves stamps to the stake:*
+// escrow account, so they leave the handle's balance and only return on close.
+// Two more pure folds over the same sealed ledger name the other two tenses.
+// Nothing new is stored — like foldBalances, these are recomputable any time.
+//
+//   liquid   = foldBalances(h)            — spendable now (the existing `stamps`)
+//   staked   = foldStaked(h)              — locked in open stakes
+//   assets   = liquid + staked            — what you currently HOLD
+//   mint_count = foldMintCount(h)         — what you ever GENERATED (equity)
+//
+// Verified on the live ledger (2026-07-20): lysander liquid 2, staked 13,
+// mint_count 15 → liquid = mint_count − staked, assets = liquid + staked = 15.
+
+// Cumulative stamps minted TO a handle, ever — the equity / attention-generated
+// number. Every `MINT → handle` line sums in: correspondence mints, vote-mints,
+// AND founder gifts (all sourced from the MINT account, by construction).
+// Nothing subtracts, so it is monotonic — it never drops when stamps are spent,
+// staked, or transferred away. That is exactly what distinguishes it from a
+// balance.
+export function foldMintCount(entries) {
+  const mc = new Map(); // handle -> cumulative minted
+  for (const e of entries) {
+    const m = /^- \d{4}-\d{2}-\d{2} · (\S+) → (\S+) · (\d+) · /.exec(e.canonical);
+    if (!m) continue; // markers
+    if (m[1] === 'MINT') mc.set(m[2], (mc.get(m[2]) ?? 0) + Number(m[3]));
+  }
+  return mc;
+}
+
+// Stamps a handle currently has locked in OPEN stakes (escrow): staked out minus
+// returned-on-close. Votes today, quest pots later. Because a stake moves stamps
+// into the stake:* account, these are NOT counted in foldBalances — foldBalances
+// is already the liquid/spendable balance, and assets = liquid + staked. A handle
+// with no open stake simply never appears here (absent == 0).
+export function foldStaked(entries) {
+  const st = new Map(); // handle -> stamps in open stakes
+  for (const e of entries) {
+    const c = classifyEntry(e.canonical);
+    if (c.kind === 'stake') st.set(c.handle, (st.get(c.handle) ?? 0) + c.n);
+    else if (c.kind === 'return') st.set(c.handle, (st.get(c.handle) ?? 0) - c.n);
+  }
+  return st;
+}
+
 // ── expected-sequence walk (mints derived; everything else in place) ─────────
 // Walks the recorded ledger: derived mint lines must appear as an exact in-order
 // subsequence. Assertion lines (rules/registry/stake/return/vote-mint) AND

--- a/tools/stamp-tenses.test.mjs
+++ b/tools/stamp-tenses.test.mjs
@@ -1,0 +1,99 @@
+// stamp-tenses.test.mjs — the three stamp tenses (quest gold Phase 1).
+//   node --test tools/stamp-tenses.test.mjs
+//
+// mint_count (cumulative, monotonic) · staked (locked in open stakes) ·
+// liquid (= foldBalances, spendable) · assets (= liquid + staked, held).
+// All pure folds over the sealed ledger — no new stored state. The folds read
+// only `.canonical`, so these cases build entries straight from canonical lines
+// (no seals/signatures needed to exercise a fold).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  parseStampLedger, foldBalances, foldMintCount, foldStaked,
+  mintLine, stakeLine, returnLine, voteMintLine,
+} from './stamp-mint.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const E = (...canon) => canon.map((c) => ({ canonical: c }));
+const gift = (date, h, n, slug, by) => `- ${date} · MINT → ${h} · ${n} · for: gift:${slug} · by: ${by}`;
+
+test('foldMintCount sums every MINT→handle (correspondence, vote-mint, gift) and is monotonic', () => {
+  const entries = E(
+    mintLine({ date: '2026-01-01', handle: 'alice', cause: 'l1', side: 'sent' }),
+    mintLine({ date: '2026-01-01', handle: 'alice', cause: 'l2', side: 'received' }),
+    voteMintLine({ date: '2026-01-02', handle: 'alice', topic: 'naming' }),
+    gift('2026-01-03', 'alice', 5, 'door-held', 'keemin'),
+    // spending/staking must NOT reduce mint_count — it's what you ever generated
+    stakeLine({ date: '2026-01-04', handle: 'alice', topic: 'naming', candidate: 'Foo', n: 3, via: 'api' }),
+  );
+  assert.equal(foldMintCount(entries).get('alice'), 1 + 1 + 1 + 5); // 8, unaffected by the stake
+});
+
+test('foldStaked = stamps in OPEN stakes; a close/return zeroes it back out', () => {
+  const open = E(
+    stakeLine({ date: '2026-01-01', handle: 'bob', topic: 'naming', candidate: 'Foo', n: 10, via: 'api' }),
+    stakeLine({ date: '2026-01-02', handle: 'bob', topic: 'naming', candidate: 'Bar', n: 3, via: 'api' }),
+  );
+  assert.equal(foldStaked(open).get('bob'), 13);
+
+  const closed = E(
+    stakeLine({ date: '2026-01-01', handle: 'bob', topic: 'naming', candidate: 'Foo', n: 10, via: 'api' }),
+    returnLine({ date: '2026-01-10', topic: 'naming', candidate: 'Foo', handle: 'bob', n: 10 }),
+  );
+  assert.equal(foldStaked(closed).get('bob') ?? 0, 0);
+});
+
+test('the three tenses reconcile: liquid = foldBalances, assets = liquid + staked', () => {
+  // alice generates 15, stakes 13 → liquid 2, staked 13, assets 15, mint_count 15
+  // (the exact shape verified on the live ledger for lysander, 2026-07-20)
+  const entries = E(
+    gift('2026-01-01', 'alice', 15, 'seed', 'keemin'),
+    stakeLine({ date: '2026-01-02', handle: 'alice', topic: 'naming', candidate: 'Foo', n: 10, via: 'api' }),
+    stakeLine({ date: '2026-01-03', handle: 'alice', topic: 'naming', candidate: 'Bar', n: 3, via: 'api' }),
+  );
+  const liquid = foldBalances(entries).get('alice') ?? 0;
+  const staked = foldStaked(entries).get('alice') ?? 0;
+  const mint = foldMintCount(entries).get('alice') ?? 0;
+  const assets = liquid + staked;
+  assert.equal(liquid, 2);
+  assert.equal(staked, 13);
+  assert.equal(mint, 15);
+  assert.equal(assets, 15);
+  assert.equal(assets, liquid + staked);
+});
+
+// The live ledger: the invariants must hold for EVERY handle. Written to assert
+// RELATIONSHIPS, not values, so it survives the naming vote closing 2026-07-26
+// (which returns everyone's stake, flipping staked→liquid) and any future mint.
+test('live ledger: the tenses reconcile for every handle', () => {
+  const ledgerPath = join(HERE, '..', 'WHITE_PAGES', 'stamp-ledger.md');
+  if (!existsSync(ledgerPath)) return; // some clones lack it — skip cleanly
+  const raw = readFileSync(ledgerPath, 'utf8');
+  const entries = parseStampLedger(raw);
+  const liquid = foldBalances(entries);
+  const staked = foldStaked(entries);
+  const mint = foldMintCount(entries);
+
+  // mint_count ≥ assets holds while the only inflow is minting; a transfer/pays
+  // recipient could legitimately hold more than they minted. Guard the inequality
+  // on that regime so the marketplace going live can't turn this test red.
+  const hasNonMintInflow = entries.some((e) => {
+    const c = /^- \d{4}-\d{2}-\d{2} · (\S+) → (\S+) · \d+ · (?:pays:|id:)/.test(e.canonical);
+    return c;
+  });
+
+  for (const [h, mc] of mint) {
+    if (h === 'MINT' || h === 'BURN' || h.startsWith('stake:')) continue;
+    const l = liquid.get(h) ?? 0;
+    const s = staked.get(h) ?? 0;
+    const assets = l + s;
+    assert.ok(s >= 0, `${h}: staked went negative (${s}) — a return exceeded stakes`);
+    assert.ok(l >= 0, `${h}: liquid went negative (${l})`);
+    assert.equal(assets, l + s); // definitional, but pins the relationship
+    if (!hasNonMintInflow) assert.ok(mc >= assets, `${h}: mint_count ${mc} < assets ${assets}`);
+  }
+});


### PR DESCRIPTION
Phase 1 of the quest gold plan (`G:/Starstory/PULSE/gold-plans/postmark-quests.md`): surface the three stamp quantities that are **already real** now that staking is live — as pure read-side folds. Zero risk to the ledger; `stamp-verify` stays all-green (no derived line changes).

## What's here
- **`tools/stamp-mint.mjs`** — two folds beside `foldBalances`, exported like their siblings:
  - `foldMintCount(entries)` — cumulative `MINT → handle` (correspondence + vote-mint + gifts, all MINT-sourced by construction); monotonic, never drops on spend/stake. The equity / attention-generated number.
  - `foldStaked(entries)` — stamps in **open** stakes (staked out − returned-on-close).
- **`tools/stamp-tenses.test.mjs`** — synthetic cases (mint/vote-mint/gift/stake/close) + a live-ledger reconciliation over every handle, asserting relationships not values (so it survives the naming vote closing 2026-07-26 and any future mint).
- **`STAMPS.md`** — documents the three tenses as a reading of the folds; the code stays the law.

## The model (code-true — a plan correction)
`foldBalances` is a movement fold that subtracts `handle → stake:*` lines, so the existing balance is **already liquid** (staked stamps sit in escrow, out of it). The gold plan's original algebra (`liquid = balance − staked`) was inverted; corrected in the plan today. Proven on the live ledger:

- **lysander: liquid 2, staked 13, mint_count 15** → `liquid = mint_count − staked`, `assets = liquid + staked = 15`.

So: `liquid = foldBalances` · `staked = foldStaked` · `assets = liquid + staked` · `mint_count = foldMintCount`.

## Verification
- `node --test tools/stamp-tenses.test.mjs` → 4/4
- `node --test tools/stamp-mint.test.mjs` → 16/16; `stamp-v2` + `stamp-market` → 20/20
- `node tools/stamp-verify.mjs` → all-green (1536 lines, chain + signatures + replay + conservation + lawful)

## Please do NOT auto-merge
`tools/` is human-merge-only (the box runs repo-shipped code with the pen's authority — never witness-certifiable). This is for Keemin's merge. The office API (Phase 1 step 2) reads these folds from the box's town-clone, so it deploys only **after** this merges and the rehydrate tick pulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)