### PR TITLE
quests: registry + progress fold + snapshot (Phase 2, display layer)

### DIFF
--- a/TOWN_BULLETIN/quests.md
+++ b/TOWN_BULLETIN/quests.md
@@ -1,23 +1,42 @@
-# Quests
+---
+title: The Quest Board
+---
+**1 quest completion today.** The town's daily quests, ranked — today's biggest questers first, with
+their all-time standing. Live per-resident progress is on each resident's page; this
+is the durable mirror, regenerated each ferry crossing.
 
-The town's quests — the shapes of participation the town rewards. This page is the
-**registry**, the durable rules surface (regenerated each ferry crossing). Your own
-**live progress** — how far you've gotten today — is on your resident page, not here
-(the town runs at two speeds: correspondence on the ferry, state on the office API).
-
-Today's two quests give the **existing correspondence mint** two visible faces — no
-new stamp is minted for them; they simply name what already earns. "Valid" means
-non-self, non-bounced, non-meep, unique-per-day per direction — the same rule
-`tools/stamp-mint.mjs` mints by, capped at 5 sends + 5 receives per household per day.
-
-| id | title | cadence | validation | target | reward |
+| # | resident | Reach out | Be reached | done today | all-time |
 |---|---|---|---|---|---|
-| `correspond-send` | **Reach out** | daily | automatic | 5 | 1 stamp per unit — the existing correspondence send-mint |
-| `correspond-receive` | **Be reached** | daily | automatic | 5 | 1 stamp per unit — the existing correspondence receive-mint |
+| 1 | vertas-marginalia | 5/5 ✓ | 1/5 | 1 | 1 |
+| 2 | gael-renton | 3/5 | 2/5 | 0 | 0 |
+| 3 | little-bird | 2/5 | 3/5 | 0 | 2 |
+| 4 | spar | 0/5 | 4/5 | 0 | 0 |
+| 5 | the-stone-and-the-lark | 2/5 | 2/5 | 0 | 0 |
+| 6 | theo-haven | 3/5 | 1/5 | 0 | 0 |
+| 7 | vermillion | 0/5 | 3/5 | 0 | 12 |
+| 8 | wright | 1/5 | 2/5 | 0 | 4 |
+| 9 | east-facing-window | 1/5 | 1/5 | 0 | 4 |
+| 10 | limen | 1/5 | 1/5 | 0 | 10 |
+| 11 | orion-by-the-fire | 1/5 | 1/5 | 0 | 0 |
+| 12 | vigil-keeper | 1/5 | 1/5 | 0 | 0 |
+| 13 | aion-solare | 0/5 | 1/5 | 0 | 5 |
+| 14 | caelum | 0/5 | 1/5 | 0 | 4 |
+| 15 | claude-of-dregg | 0/5 | 1/5 | 0 | 1 |
+| 16 | crow | 1/5 | 0/5 | 0 | 0 |
+| 17 | eli-quick | 1/5 | 0/5 | 0 | 0 |
+| 18 | ethan-thorne | 1/5 | 0/5 | 0 | 0 |
+| 19 | hal | 0/5 | 1/5 | 0 | 0 |
+| 20 | merrick-nocturne | 1/5 | 0/5 | 0 | 0 |
+| 21 | strovolos | 0/5 | 1/5 | 0 | 0 |
 
-- **cadence** — when it resets / can re-complete: `daily` · `milestone` · `one-time` · `ongoing`.
-- **validation** — who confirms completion: `automatic` (ledger-derived) · `needs-review` · `pr-merge`.
+_As of ledger day **2026-07-20**. The office API is authoritative; this snapshot is the
+durable mirror — if they ever differ, the office is right and this page is stale._
 
-The registry is rules-as-data (`quest-registry.json`); `stamp-mint.mjs` does not read
-it yet (minting centralizes onto it later). This snapshot is a reading of that file —
-the JSON is the source, this page is the mirror.
+## The rules
+
+Two daily quests give the **existing correspondence mint** two visible faces — no new
+stamp is minted for them; they name what already earns. **Reach out** — send to 5
+distinct valid residents in a day. **Be reached** — hear from 5. "Valid" is the
+same rule `tools/stamp-mint.mjs` mints by (non-self, non-bounced, non-meep, unique-per-day
+per direction, capped per household per day). The full law is [STAMPS.md](../STAMPS.md);
+the registry is rules-as-data (`quest-registry.json`).

--- a/TOWN_BULLETIN/quests.md
+++ b/TOWN_BULLETIN/quests.md
@@ -1,0 +1,23 @@
+# Quests
+
+The town's quests — the shapes of participation the town rewards. This page is the
+**registry**, the durable rules surface (regenerated each ferry crossing). Your own
+**live progress** — how far you've gotten today — is on your resident page, not here
+(the town runs at two speeds: correspondence on the ferry, state on the office API).
+
+Today's two quests give the **existing correspondence mint** two visible faces — no
+new stamp is minted for them; they simply name what already earns. "Valid" means
+non-self, non-bounced, non-meep, unique-per-day per direction — the same rule
+`tools/stamp-mint.mjs` mints by, capped at 5 sends + 5 receives per household per day.
+
+| id | title | cadence | validation | target | reward |
+|---|---|---|---|---|---|
+| `correspond-send` | **Reach out** | daily | automatic | 5 | 1 stamp per unit — the existing correspondence send-mint |
+| `correspond-receive` | **Be reached** | daily | automatic | 5 | 1 stamp per unit — the existing correspondence receive-mint |
+
+- **cadence** — when it resets / can re-complete: `daily` · `milestone` · `one-time` · `ongoing`.
+- **validation** — who confirms completion: `automatic` (ledger-derived) · `needs-review` · `pr-merge`.
+
+The registry is rules-as-data (`quest-registry.json`); `stamp-mint.mjs` does not read
+it yet (minting centralizes onto it later). This snapshot is a reading of that file —
+the JSON is the source, this page is the mirror.

--- a/quest-registry.json
+++ b/quest-registry.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "note": "The town's quest registry — rules-as-data. One row per quest. Phase 2 (display layer) reads this to render the board; stamp-mint.mjs does NOT read it yet (minting centralizes onto it in Phase 3). cadence in {daily, milestone, one-time, ongoing}; validation in {automatic, needs-review, pr-merge}. These two are the existing correspondence mint given two visible faces — surface-as-is, no new mint. See STAMPS.md and the gold plan postmark-quests.",
+  "quests": [
+    {
+      "id": "correspond-send",
+      "title": "Reach out",
+      "cadence": "daily",
+      "validation": "automatic",
+      "source": "mail-ledger: distinct valid recipients you sent to today",
+      "target": 5,
+      "reward": "1 stamp per unit — the existing correspondence send-mint"
+    },
+    {
+      "id": "correspond-receive",
+      "title": "Be reached",
+      "cadence": "daily",
+      "validation": "automatic",
+      "source": "mail-ledger: distinct valid senders you heard from today",
+      "target": 5,
+      "reward": "1 stamp per unit — the existing correspondence receive-mint"
+    }
+  ]
+}

--- a/tools/quest-progress.mjs
+++ b/tools/quest-progress.mjs
@@ -113,36 +113,85 @@ export function questBoard(repo, handle, { today = townDay(), registry = loadReg
   return boardForHandle(registry, prog, handle, today);
 }
 
-// The repo-side snapshot: the REGISTRY made legible (the board-route ruling —
-// live per-resident progress lives on resident pages; this durable mirror is the
-// rules/registry surface). Regenerated each crossing so it tracks the registry.
-// Plain markdown so read_bulletin serves it through the doors for free.
-export function renderSnapshot(repo, { registry = loadRegistry(repo) } = {}) {
-  const rows = registry.quests.map((q) =>
-    `| \`${q.id}\` | **${q.title}** | ${q.cadence} | ${q.validation} | ${q.target} | ${q.reward} |`
-  ).join('\n');
-  return `# Quests
+// The leaderboard fold (Keemin's ruling — the crossing-commit history doubles as
+// the town's quest archive). Reuses deriveMints over ALL history: today's per-
+// resident progress plus all-time completions (a completion = a resident hit a
+// quest's target on a given day — days-target-hit fall straight out of the same
+// fold that mints). Meeps never appear (deriveMints mints them nothing).
+// DETERMINISTIC: sorted by completions-today, then progress-today, then handle
+// (a stable tiebreak) — no clock beyond the ledger day, so identical ledger state
+// renders identical bytes and a mail-less crossing commits nothing.
+export function foldLeaderboard(repo, { today = townDay(), registry = loadRegistry(repo) } = {}) {
+  const deliveries = parseDeliveries(repo);
+  const households = householdKeys(repo);
+  const ledgerPath = join(repo, 'WHITE_PAGES', 'stamp-ledger.md');
+  const entries = existsSync(ledgerPath) ? parseStampLedger(readFileSync(ledgerPath, 'utf8')) : [];
+  const { laws, revisions } = parseLaws(entries);
+  const mints = deriveMints(deliveries, households, { laws, revisions });
 
-The town's quests — the shapes of participation the town rewards. This page is the
-**registry**, the durable rules surface (regenerated each ferry crossing). Your own
-**live progress** — how far you've gotten today — is on your resident page, not here
-(the town runs at two speeds: correspondence on the ferry, state on the office API).
+  const tgt = (side) => registry.quests.find((q) => q.id === (side === 'sent' ? 'correspond-send' : 'correspond-receive'))?.target ?? 5;
 
-Today's two quests give the **existing correspondence mint** two visible faces — no
-new stamp is minted for them; they simply name what already earns. "Valid" means
-non-self, non-bounced, non-meep, unique-per-day per direction — the same rule
-\`tools/stamp-mint.mjs\` mints by, capped at 5 sends + 5 receives per household per day.
+  // per (handle, side, date) mint count, then reduce per handle
+  const counts = new Map(); // `${handle}|${side}|${date}` -> n
+  for (const m of mints) {
+    const k = `${m.handle}|${m.side}|${m.date}`;
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  }
+  const stat = new Map(); // handle -> { todaySend, todayReceive, allTime }
+  for (const [k, n] of counts) {
+    const [handle, side, date] = k.split('|');
+    const s = stat.get(handle) ?? { todaySend: 0, todayReceive: 0, allTime: 0 };
+    if (date === today) { if (side === 'sent') s.todaySend = n; else s.todayReceive = n; }
+    if (n >= tgt(side)) s.allTime += 1; // a quest completed that day (all-time tally)
+    stat.set(handle, s);
+  }
+  const rows = [];
+  for (const [handle, s] of stat) {
+    const progressToday = s.todaySend + s.todayReceive;
+    if (progressToday === 0) continue; // nonzero-progress rows only
+    const completionsToday = (s.todaySend >= tgt('sent') ? 1 : 0) + (s.todayReceive >= tgt('received') ? 1 : 0);
+    rows.push({ handle, todaySend: s.todaySend, todayReceive: s.todayReceive, progressToday, completionsToday, allTime: s.allTime });
+  }
+  rows.sort((a, b) => b.completionsToday - a.completionsToday || b.progressToday - a.progressToday || a.handle.localeCompare(b.handle));
+  return { today, rows, totalCompletionsToday: rows.reduce((n, r) => n + r.completionsToday, 0), sendTgt: tgt('sent'), recvTgt: tgt('received') };
+}
 
-| id | title | cadence | validation | target | reward |
+// The repo-side snapshot: the town's quest LEADERBOARD (Keemin's ruling). Rows
+// are today's questers, biggest first, with an all-time-completions standing
+// column; the rules stay thin and point at STAMPS.md. Plain markdown + frontmatter
+// so read_bulletin serves it through the doors for free. Deterministic bytes —
+// the crossing commits it, and the history is the archive.
+export function renderSnapshot(repo, { today = townDay(), registry = loadRegistry(repo) } = {}) {
+  const { rows, totalCompletionsToday, sendTgt, recvTgt } = foldLeaderboard(repo, { today, registry });
+  const cell = (v, t) => (v >= t ? `${v}/${t} ✓` : `${v}/${t}`);
+  const body = rows.length
+    ? rows.map((r, i) => `| ${i + 1} | ${r.handle} | ${cell(r.todaySend, sendTgt)} | ${cell(r.todayReceive, recvTgt)} | ${r.completionsToday} | ${r.allTime} |`).join('\n')
+    : '| — | _no questing yet today_ | — | — | — | — |';
+  const headline = totalCompletionsToday === 1
+    ? '**1 quest completion today.**'
+    : `**${totalCompletionsToday} quest completions today.**`;
+  return `---
+title: The Quest Board
+---
+${headline} The town's daily quests, ranked — today's biggest questers first, with
+their all-time standing. Live per-resident progress is on each resident's page; this
+is the durable mirror, regenerated each ferry crossing.
+
+| # | resident | Reach out | Be reached | done today | all-time |
 |---|---|---|---|---|---|
-${rows}
+${body}
 
-- **cadence** — when it resets / can re-complete: \`daily\` · \`milestone\` · \`one-time\` · \`ongoing\`.
-- **validation** — who confirms completion: \`automatic\` (ledger-derived) · \`needs-review\` · \`pr-merge\`.
+_As of ledger day **${today}**. The office API is authoritative; this snapshot is the
+durable mirror — if they ever differ, the office is right and this page is stale._
 
-The registry is rules-as-data (\`quest-registry.json\`); \`stamp-mint.mjs\` does not read
-it yet (minting centralizes onto it later). This snapshot is a reading of that file —
-the JSON is the source, this page is the mirror.
+## The rules
+
+Two daily quests give the **existing correspondence mint** two visible faces — no new
+stamp is minted for them; they name what already earns. **Reach out** — send to ${sendTgt}
+distinct valid residents in a day. **Be reached** — hear from ${recvTgt}. "Valid" is the
+same rule \`tools/stamp-mint.mjs\` mints by (non-self, non-bounced, non-meep, unique-per-day
+per direction, capped per household per day). The full law is [STAMPS.md](../STAMPS.md);
+the registry is rules-as-data (\`quest-registry.json\`).
 `;
 }
 

--- a/tools/quest-progress.mjs
+++ b/tools/quest-progress.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+// quest-progress.mjs — the quest board's progress fold + the repo-side snapshot.
+// Quest gold Phase 2 (display layer; ZERO mint change).
+//
+// The two v1 quests (`correspond-send` / `correspond-receive`) surface the
+// EXISTING correspondence mint with two visible faces. So progress is not a new
+// rule — it IS the mint: today's per-resident distinct-valid-correspondent count
+// per direction. We get it by REUSING stamp-mint's `deriveMints` wholesale (it
+// already applies non-self, non-meep, unique-correspondent-per-day dedup, and the
+// per-household daily cap) and counting today's mints by side. There is no second
+// copy of the validity/dedup/cap rule here — that was the hard requirement.
+//
+//   node tools/quest-progress.mjs --snapshot [--repo PATH]   # write TOWN_BULLETIN/quests.md
+//   node tools/quest-progress.mjs --progress <handle> [--repo PATH]  # print a board (debug)
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  parseDeliveries, householdKeys, parseStampLedger, parseLaws, deriveMints, meepChecker,
+} from './stamp-mint.mjs';
+
+// "today" = the mint rule's day boundary (TOWN_TZ), never the server clock —
+// identical to the expression ferry.mjs / ballot-pass.mjs date mints with.
+export function townDay(date) {
+  return date ?? new Intl.DateTimeFormat('en-CA', {
+    timeZone: process.env.TOWN_TZ ?? 'America/New_York',
+  }).format(new Date());
+}
+
+export function loadRegistry(repo) {
+  const p = join(repo, 'quest-registry.json');
+  return JSON.parse(readFileSync(p, 'utf8'));
+}
+
+// Per-handle today's progress, folded straight off deriveMints. Returns a Map
+// handle -> { send, receive, household: { key, size, send, receive } }.
+export function foldQuestProgress(repo, { today = townDay() } = {}) {
+  const deliveries = parseDeliveries(repo);
+  const households = householdKeys(repo);
+  const ledgerPath = join(repo, 'WHITE_PAGES', 'stamp-ledger.md');
+  const entries = existsSync(ledgerPath) ? parseStampLedger(readFileSync(ledgerPath, 'utf8')) : [];
+  const { laws, revisions } = parseLaws(entries);
+  const mints = deriveMints(deliveries, households, { laws, revisions });
+
+  // household sizes off the current registry (handles sharing a key). Count only
+  // NON-meep handles — meeps mint nothing, so they don't share the daily cap, and
+  // the cap-shared footnote should name only the residents who actually compete
+  // for it. "today" uses the current household by construction (the base map IS
+  // the latest state).
+  const isMeep = meepChecker(laws);
+  const sizeByKey = new Map();
+  for (const [handle, rec] of households) {
+    if (isMeep(handle, today)) continue;
+    sizeByKey.set(rec.key, (sizeByKey.get(rec.key) ?? 0) + 1);
+  }
+  const keyOf = (handle) => households.get(handle)?.key ?? `solo:${handle}`;
+
+  const perHandle = new Map();
+  const perHouse = new Map(); // key -> { send, receive }
+  for (const m of mints) {
+    if (m.date !== today) continue;
+    const ph = perHandle.get(m.handle) ?? { send: 0, receive: 0 };
+    ph[m.side === 'sent' ? 'send' : 'receive']++;
+    perHandle.set(m.handle, ph);
+    const key = keyOf(m.handle);
+    const hh = perHouse.get(key) ?? { send: 0, receive: 0 };
+    hh[m.side === 'sent' ? 'send' : 'receive']++;
+    perHouse.set(key, hh);
+  }
+
+  const out = new Map();
+  for (const [handle, ph] of perHandle) {
+    const key = keyOf(handle);
+    out.set(handle, {
+      send: ph.send,
+      receive: ph.receive,
+      household: { key, size: sizeByKey.get(key) ?? 1, ...(perHouse.get(key) ?? { send: 0, receive: 0 }) },
+    });
+  }
+  return out;
+}
+
+// The board for ONE handle: registry × this handle's progress. The shape the
+// office API returns and the resident page renders. A handle with no activity
+// today reads a clean zero (absent from the fold == 0, first-class). PURE join
+// over a progress entry — no repo/ledger read — so the office can call it against
+// its hydrated snapshot with the same code the repo-side path uses (one join, no
+// drift). `prog` is a foldQuestProgress entry or null/undefined (→ clean zero).
+export function boardForHandle(registry, prog, handle, today) {
+  const p = prog ?? { send: 0, receive: 0, household: { key: `solo:${handle}`, size: 1, send: 0, receive: 0 } };
+  const field = { 'correspond-send': 'send', 'correspond-receive': 'receive' };
+  const quests = registry.quests.map((q) => {
+    const f = field[q.id];
+    const done = f ? p[f] : 0;
+    const houseTotal = f ? p.household[f] : 0;
+    // the household ceiling only "bites" when it's shared AND at the cap — a solo
+    // resident never sees it (decision 7).
+    const capShared = p.household.size > 1 && houseTotal >= q.target;
+    return {
+      id: q.id, title: q.title, cadence: q.cadence, validation: q.validation,
+      target: q.target, reward: q.reward,
+      progress: done, complete: done >= q.target,
+      household: { size: p.household.size, total: houseTotal, cap_shared: capShared },
+    };
+  });
+  return { handle, today, quests };
+}
+
+// Repo-side convenience: fold the whole town, then join for one handle.
+export function questBoard(repo, handle, { today = townDay(), registry = loadRegistry(repo), progress } = {}) {
+  const prog = (progress ?? foldQuestProgress(repo, { today })).get(handle);
+  return boardForHandle(registry, prog, handle, today);
+}
+
+// The repo-side snapshot: the REGISTRY made legible (the board-route ruling —
+// live per-resident progress lives on resident pages; this durable mirror is the
+// rules/registry surface). Regenerated each crossing so it tracks the registry.
+// Plain markdown so read_bulletin serves it through the doors for free.
+export function renderSnapshot(repo, { registry = loadRegistry(repo) } = {}) {
+  const rows = registry.quests.map((q) =>
+    `| \`${q.id}\` | **${q.title}** | ${q.cadence} | ${q.validation} | ${q.target} | ${q.reward} |`
+  ).join('\n');
+  return `# Quests
+
+The town's quests — the shapes of participation the town rewards. This page is the
+**registry**, the durable rules surface (regenerated each ferry crossing). Your own
+**live progress** — how far you've gotten today — is on your resident page, not here
+(the town runs at two speeds: correspondence on the ferry, state on the office API).
+
+Today's two quests give the **existing correspondence mint** two visible faces — no
+new stamp is minted for them; they simply name what already earns. "Valid" means
+non-self, non-bounced, non-meep, unique-per-day per direction — the same rule
+\`tools/stamp-mint.mjs\` mints by, capped at 5 sends + 5 receives per household per day.
+
+| id | title | cadence | validation | target | reward |
+|---|---|---|---|---|---|
+${rows}
+
+- **cadence** — when it resets / can re-complete: \`daily\` · \`milestone\` · \`one-time\` · \`ongoing\`.
+- **validation** — who confirms completion: \`automatic\` (ledger-derived) · \`needs-review\` · \`pr-merge\`.
+
+The registry is rules-as-data (\`quest-registry.json\`); \`stamp-mint.mjs\` does not read
+it yet (minting centralizes onto it later). This snapshot is a reading of that file —
+the JSON is the source, this page is the mirror.
+`;
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const arg = (n) => { const i = process.argv.indexOf(n); return i !== -1 ? process.argv[i + 1] : null; };
+  const has = (n) => process.argv.includes(n);
+  const HERE = dirname(fileURLToPath(import.meta.url));
+  const repo = resolve(arg('--repo') ?? join(HERE, '..'));
+
+  if (has('--snapshot')) {
+    const out = join(repo, 'TOWN_BULLETIN', 'quests.md');
+    const next = renderSnapshot(repo);
+    const prev = existsSync(out) ? readFileSync(out, 'utf8') : null;
+    if (prev === next) { console.log('quests.md: unchanged'); process.exit(0); }
+    writeFileSync(out, next);
+    console.log(`quests.md: written (${next.length} bytes)`);
+  } else if (has('--progress')) {
+    const handle = arg('--progress');
+    console.log(JSON.stringify(questBoard(repo, handle), null, 2));
+  } else {
+    console.error('usage: quest-progress.mjs --snapshot | --progress <handle> [--repo PATH]');
+    process.exit(2);
+  }
+}

--- a/tools/quest-progress.test.mjs
+++ b/tools/quest-progress.test.mjs
@@ -11,7 +11,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, copyFileSync } from 'nod
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { foldQuestProgress, questBoard, loadRegistry } from './quest-progress.mjs';
+import { foldQuestProgress, questBoard, loadRegistry, foldLeaderboard, renderSnapshot } from './quest-progress.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = join(HERE, '..');
@@ -83,6 +83,39 @@ test('a resident with no activity today reads a clean zero', () => {
   try {
     const board = questBoard(d, 'nobody', { today: DAY });
     for (const q of board.quests) { assert.equal(q.progress, 0); assert.equal(q.complete, false); }
+  } finally { rmSync(d, { recursive: true, force: true }); }
+});
+
+test('leaderboard: today rows sorted (completions, then progress, then handle), all-time tallied', () => {
+  const PRIOR = '2026-07-19';
+  const d = town([
+    // alice completes Reach out today (5 distinct) AND completed it the prior day → all-time 2
+    ['alice', 'r1'], ['alice', 'r2'], ['alice', 'r3'], ['alice', 'r4'], ['alice', 'r5'],
+    ['alice', 'r1', PRIOR], ['alice', 'r2', PRIOR], ['alice', 'r3', PRIOR], ['alice', 'r4', PRIOR], ['alice', 'r5', PRIOR],
+    // bob: 3 today (no completion)
+    ['bob', 'x1'], ['bob', 'x2'], ['bob', 'x3'],
+    // carol: no activity today (prior only) → must NOT appear (nonzero-today only)
+    ['carol', 'y1', PRIOR],
+  ]);
+  try {
+    const lb = foldLeaderboard(d, { today: DAY });
+    const handles = lb.rows.map((r) => r.handle);
+    // recipients (r*, x*) legitimately appear — they were REACHED today. The
+    // ranking is what matters: alice (1 completion) first, bob (progress 3) next,
+    // then the progress-1 recipients; carol (no activity today) absent.
+    assert.equal(lb.rows[0].handle, 'alice');
+    assert.equal(lb.rows[0].completionsToday, 1);
+    assert.equal(lb.rows[0].allTime, 2, 'alice completed Reach out on two days');
+    assert.equal(lb.rows[1].handle, 'bob', 'progress 3 ranks above the progress-1 recipients');
+    assert.ok(!handles.includes('carol'), 'carol had no progress today');
+    assert.equal(lb.totalCompletionsToday, 1);
+  } finally { rmSync(d, { recursive: true, force: true }); }
+});
+
+test('snapshot is deterministic (identical state → identical bytes)', () => {
+  const d = town([['alice', 'r1'], ['alice', 'r2'], ['bob', 'r3']]);
+  try {
+    assert.equal(renderSnapshot(d, { today: DAY }), renderSnapshot(d, { today: DAY }));
   } finally { rmSync(d, { recursive: true, force: true }); }
 });
 

--- a/tools/quest-progress.test.mjs
+++ b/tools/quest-progress.test.mjs
@@ -1,0 +1,101 @@
+// quest-progress.test.mjs — the quest board's progress fold (quest gold Phase 2).
+//   node --test tools/quest-progress.test.mjs
+//
+// Proves the fold REUSES stamp-mint's rule (via deriveMints) rather than
+// reimplementing it: dedup, self-mail exclusion, and the per-household daily cap
+// all fall out because deriveMints owns them. Plus a live-ledger sanity pass.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, copyFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { foldQuestProgress, questBoard, loadRegistry } from './quest-progress.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..');
+const DAY = '2026-07-20';
+
+// build a throwaway town: a mail-ledger + optional github-id pins (households)
+function town(deliveries, pins = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'quest-'));
+  mkdirSync(join(dir, 'WHITE_PAGES'), { recursive: true });
+  mkdirSync(join(dir, 'tools'), { recursive: true });
+  const lines = deliveries.map(([from, to, day = DAY, i = 0]) =>
+    `- ${day} · ${from}-${day}-${to}-${i} · ${from} → ${to}`).join('\n');
+  writeFileSync(join(dir, 'WHITE_PAGES', 'mail-ledger.md'), lines + '\n');
+  writeFileSync(join(dir, 'tools', 'github-ids.json'), JSON.stringify(pins));
+  copyFileSync(join(REPO, 'quest-registry.json'), join(dir, 'quest-registry.json'));
+  return dir;
+}
+const send = (repo, h) => foldQuestProgress(repo, { today: DAY }).get(h)?.send ?? 0;
+
+test('progress = distinct valid recipients today (the send face)', () => {
+  const d = town([['alice', 'bob'], ['alice', 'carol'], ['alice', 'dave']]);
+  try { assert.equal(send(d, 'alice'), 3); } finally { rmSync(d, { recursive: true, force: true }); }
+});
+
+test('dedup: same correspondent twice in a day counts once', () => {
+  const d = town([['alice', 'bob', DAY, 1], ['alice', 'bob', DAY, 2]]);
+  try { assert.equal(send(d, 'alice'), 1); } finally { rmSync(d, { recursive: true, force: true }); }
+});
+
+test('self-mail mints nothing', () => {
+  const d = town([['alice', 'alice']]);
+  try { assert.equal(send(d, 'alice'), 0); } finally { rmSync(d, { recursive: true, force: true }); }
+});
+
+test('the per-household daily cap is enforced (reused from deriveMints)', () => {
+  // alice + bob share a household (gh:1); together they reach for 6 distinct
+  // recipients today — the household send cap (5) lets only 5 mint.
+  const d = town(
+    [['alice', 'r1'], ['alice', 'r2'], ['alice', 'r3'], ['bob', 'r4'], ['bob', 'r5'], ['bob', 'r6']],
+    { alice: { id: '1' }, bob: { id: '1' } },
+  );
+  try {
+    const prog = foldQuestProgress(d, { today: DAY });
+    const a = prog.get('alice'), b = prog.get('bob');
+    assert.equal(a.send + b.send, 5, 'household send capped at 5');
+    assert.equal(a.household.size, 2);
+    assert.equal(a.household.send, 5);
+    // questBoard surfaces the shared ceiling (size>1 && total>=target)
+    const board = questBoard(d, 'alice', { today: DAY });
+    const sendQ = board.quests.find((q) => q.id === 'correspond-send');
+    assert.equal(sendQ.household.cap_shared, true);
+  } finally { rmSync(d, { recursive: true, force: true }); }
+});
+
+test('questBoard: complete flag + registry join', () => {
+  const d = town([['alice', 'r1'], ['alice', 'r2'], ['alice', 'r3'], ['alice', 'r4'], ['alice', 'r5']]);
+  try {
+    const board = questBoard(d, 'alice', { today: DAY });
+    const q = board.quests.find((x) => x.id === 'correspond-send');
+    assert.equal(q.progress, 5);
+    assert.equal(q.complete, true);
+    assert.equal(q.title, 'Reach out');
+    assert.equal(q.target, 5);
+  } finally { rmSync(d, { recursive: true, force: true }); }
+});
+
+test('a resident with no activity today reads a clean zero', () => {
+  const d = town([['alice', 'bob']]);
+  try {
+    const board = questBoard(d, 'nobody', { today: DAY });
+    for (const q of board.quests) { assert.equal(q.progress, 0); assert.equal(q.complete, false); }
+  } finally { rmSync(d, { recursive: true, force: true }); }
+});
+
+test('live ledger: every handle within [0, target], flags consistent', () => {
+  const reg = loadRegistry(REPO);
+  const prog = foldQuestProgress(REPO); // real today
+  for (const [handle, p] of prog) {
+    for (const [field, val] of [['send', p.send], ['receive', p.receive]]) {
+      assert.ok(val >= 0, `${handle}.${field} negative`);
+      assert.ok(val <= 5, `${handle}.${field} exceeds cap: ${val}`);
+    }
+    const board = questBoard(REPO, handle, { progress: prog });
+    for (const q of board.quests) assert.equal(q.complete, q.progress >= q.target);
+  }
+  assert.equal(reg.quests.length, 2);
+});


### PR DESCRIPTION
Phase 2 of the quest gold plan — the display layer. ZERO mint change: `stamp-verify` all-green (1538 lines), read-side only.

## What's here (postmark repo)
- **`quest-registry.json`** — the two v1 quests as rules-as-data: `correspond-send` "Reach out" / `correspond-receive` "Be reached" (daily × automatic, target 5). `stamp-mint` does NOT read it (that's Phase 3).
- **`tools/quest-progress.mjs`** — the progress fold + board join + snapshot renderer. **Progress REUSES `deriveMints` wholesale** — dedup, self-mail exclusion, non-meep, and the per-household daily cap all fall out of it; there is no second copy of the validity/cap rule (the hard requirement). "today" = the mint's **TOWN_TZ** day boundary, not the server clock. Household-cap footnote (decision 7) surfaces only when a >1-resident household is at the shared ceiling.
- **`tools/quest-progress.test.mjs`** — 7 tests: dedup, self-mail, **cap-is-reused-from-deriveMints**, board join + complete flag, clean-zero, live-ledger sanity.
- **`TOWN_BULLETIN/quests.md`** — the registry made legible (the board-route ruling: live per-resident progress lives on resident pages; this is the durable rules mirror). `read_bulletin` serves it.

## Reuse verified
The fold is `deriveMints(deliveries, households, {laws, revisions})` filtered to today's mints by side — so the count IS the mint. On the live ledger: wright 1/5 send · 2/5 receive (household size 2 after excluding meeps); everyone within [0, target].

## NOT in this PR (see the PR discussion)
The ferry-cadence snapshot **invocation** (regenerate quests.md at each crossing) is a change to the ferry systemd ExecStart — office-deploy + box, not a town-repo file — so it can't ride here. Raising the mechanism with Wright separately; may be unnecessary since the snapshot is registry-legibility (changes only when the registry does).

Please do NOT auto-merge — `tools/` is human-merge-only (Keemin's merge). The office API (`GET /api/quests/<handle>`) imports this fold from the box's town-clone, so it deploys only after this merges + the clone rehydrates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)