### PR TITLE
window: bump Volvigradus's hand-tallied pet count to 777

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -1516,7 +1516,7 @@ function setStagePage() {
 
 // the town keeps no ledger for this either — same as the coins. This number
 // is hand-set, bumped by hand when asked, not computed from anything live.
-var VOLVIGRADUS_HAND_TALLY = 7;
+var VOLVIGRADUS_HAND_TALLY = 777;
 var volvigradusLastPat = 0;
 function patVolvigradus() {
   var now = Date.now();


### PR DESCRIPTION
One-line hand bump, same as the coin ledger convention: career total 7 -> 777. Verified in-browser on the terraced garden panel.