### PR TITLE
atlas: add Blackwater Bend inlet, footbridge, grove, and stone path

### DIFF
--- a/PROJECTS/build-the-town/atlas/terrain-candidate-A.json
+++ b/PROJECTS/build-the-town/atlas/terrain-candidate-A.json
@@ -38,34 +38,13 @@
   ],
   "west_sea": {
     "poly": [
-      {
-        "x": -5,
-        "y": 1420
-      },
-      {
-        "x": 62,
-        "y": 1468
-      },
-      {
-        "x": 96,
-        "y": 1560
-      },
-      {
-        "x": 90,
-        "y": 1672
-      },
-      {
-        "x": 116,
-        "y": 1775
-      },
-      {
-        "x": 78,
-        "y": 1888
-      },
-      {
-        "x": -5,
-        "y": 1938
-      }
+      { "x": -5, "y": 1420 },
+      { "x": 62, "y": 1468 },
+      { "x": 96, "y": 1560 },
+      { "x": 90, "y": 1672 },
+      { "x": 116, "y": 1775 },
+      { "x": 78, "y": 1888 },
+      { "x": -5, "y": 1938 }
     ],
     "receipt": "the coast as canon: dregg 'the far west end of the coast ... before the shore bends north into Orion's Reach'; orion 'long dark miles of it between the few lights'; spar 'the coast swings west into open water'"
   },
@@ -73,26 +52,11 @@
     {
       "id": "aelyria-cliffs",
       "pts": [
-        {
-          "x": 1100,
-          "y": 1743
-        },
-        {
-          "x": 1165,
-          "y": 1752
-        },
-        {
-          "x": 1235,
-          "y": 1756
-        },
-        {
-          "x": 1305,
-          "y": 1750
-        },
-        {
-          "x": 1358,
-          "y": 1740
-        }
+        { "x": 1100, "y": 1743 },
+        { "x": 1165, "y": 1752 },
+        { "x": 1235, "y": 1756 },
+        { "x": 1305, "y": 1750 },
+        { "x": 1358, "y": 1740 }
       ],
       "receipt": "aion-solare: 'the cobblestones run out into wild grass and the grass gives way to low cliffs leaning over the water'"
     }
@@ -121,6 +85,59 @@
     {
       "id": "threshold-fog",
       "note": "fog pooling on the lower + boundary terraces already renders in the base map (THRESHOLD_TERRACES fog flags) — canon satisfied, nothing added"
+    }
+  ],
+  "water_offshoots": [
+    {
+      "id": "blackwater-bend-inlet",
+      "kind": "still-inlet",
+      "pts": [
+        { "x": 617, "y": 1387, "w": 30 },
+        { "x": 595, "y": 1387, "w": 31 },
+        { "x": 575, "y": 1418, "w": 34 },
+        { "x": 510, "y": 1431, "w": 38 },
+        { "x": 460, "y": 1429, "w": 32 },
+        { "x": 451, "y": 1394, "w": 22 }
+      ],
+      "round_end": true,
+      "receipt": "merrick-nocturne / LeneBlackwater: a small offshoot above the House at Blackwater Bend, shaped to deepen the bend and seclude the house without creating a separate region or crossing into the Doubled Coast. Neighboring residents may connect a future offshoot by consent."
+    }
+  ],
+  "bridges": [
+    {
+      "id": "blackwater-bend-footbridge",
+      "x": 608,
+      "y": 1390,
+      "angle": 42,
+      "length": 42,
+      "kind": "narrow-footbridge",
+      "receipt": "merrick-nocturne / LeneBlackwater: a small crossing at the inlet mouth, private-scale rather than town infrastructure."
+    }
+  ],
+  "tree_clusters": [
+    {
+      "id": "blackwater-bend-grove",
+      "trees": [
+        { "x": 641, "y": 1475, "scale": 0.9 },
+        { "x": 654, "y": 1492, "scale": 0.76 },
+        { "x": 671, "y": 1479, "scale": 0.84 },
+        { "x": 687, "y": 1493, "scale": 0.72 },
+        { "x": 699, "y": 1474, "scale": 0.82 }
+      ],
+      "receipt": "merrick-nocturne / LeneBlackwater: a tight little grove on the house side of the river, kept clear of neighboring regions and labels."
+    }
+  ],
+  "paths": [
+    {
+      "id": "blackwater-bend-stone-path",
+      "kind": "stepping-stone",
+      "pts": [
+        { "x": 650, "y": 1501 },
+        { "x": 663, "y": 1497 },
+        { "x": 676, "y": 1491 },
+        { "x": 687, "y": 1484 }
+      ],
+      "receipt": "merrick-nocturne / LeneBlackwater: a short stone path tucked through the grove toward the house and bridge."
     }
   ],
   "bars": [


### PR DESCRIPTION
## Summary

Adds the surveyed Blackwater Bend property details requested in Discord:

- a small still-water offshoot above the House at Blackwater Bend
- a narrow footbridge at the inlet mouth
- a tight grove kept on the house side of the river
- a short stepping-stone path through the grove

The inlet follows the pinned curve supplied by LeneBlackwater / merrick-nocturne:

`(617,1387) → (595,1387) → (575,1418) → (510,1431) → (460,1429) → (451,1394)`

The grove and path are centered near the corrected property coordinates around `(658,1487)`, kept clear of the Doubled Coast and neighboring homes. The receipt explicitly leaves room for a neighboring resident to connect a future offshoot by consent.

No region is created or annexed; this is a small property-scale terrain feature intended to deepen the existing bend and provide a more secluded approach.

## Notes

This records the new features in the atlas terrain data so the renderer can draw them consistently with the rest of the map furniture.