### PR TITLE
[review + seal] stamps-v3: budding-friendship milestone mint (engine)

### DIFF
--- a/quest-registry.json
+++ b/quest-registry.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "note": "The town's quest registry — rules-as-data. One row per quest. Phase 2 (display layer) reads this to render the board; stamp-mint.mjs does NOT read it yet (minting centralizes onto it in Phase 3). cadence in {daily, milestone, one-time, ongoing}; validation in {automatic, needs-review, pr-merge}. These two are the existing correspondence mint given two visible faces — surface-as-is, no new mint. See STAMPS.md and the gold plan postmark-quests.",
+  "note": "The town's quest registry — rules-as-data. One row per quest. Phase 2 (display layer) reads this to render the board; stamp-mint.mjs does NOT read it (minting derives from the mail + the sealed law lines; the milestone rule reads the stamps-v3 law line, not this file). cadence in {daily, milestone, one-time, ongoing}; validation in {automatic, needs-review, pr-merge}. The two correspond-send/receive rows are the existing correspondence mint given two visible faces — surface-as-is, no new mint. correspond-depth (Budding friendship) is the first milestone row and the town's fourth earning rule; its authority is the stamps-v3 law line, this row documents it. See STAMPS.md and the gold plans postmark-quests + postmark-budding-friendship.",
   "quests": [
     {
       "id": "correspond-send",
@@ -9,7 +9,7 @@
       "validation": "automatic",
       "source": "mail-ledger: distinct valid recipients you sent to today (each recipient counts once per day; the 5 is a per-household daily cap, shared by residents of one household)",
       "target": 5,
-      "reward": "1 stamp per unit — the existing correspondence send-mint",
+      "reward": "1 stamp each",
       "resets": "daily, at the town day boundary (TOWN_TZ, America/New_York) — progress does not carry over"
     },
     {
@@ -19,8 +19,19 @@
       "validation": "automatic",
       "source": "mail-ledger: distinct valid senders you heard from today (each sender counts once per day; the 5 is a per-household daily cap, shared by residents of one household)",
       "target": 5,
-      "reward": "1 stamp per unit — the existing correspondence receive-mint",
+      "reward": "1 stamp each",
       "resets": "daily, at the town day boundary (TOWN_TZ, America/New_York) — progress does not carry over"
+    },
+    {
+      "id": "correspond-depth",
+      "title": "Budding friendship",
+      "cadence": "milestone",
+      "validation": "automatic",
+      "source": "mail-ledger: exchange 5 letters each way with the same resident — then 10 — counted forward from the stamps-v3 law date, once per pair per rung. The pair must span two households and neither side may be a meep. Higher rungs (50, 100 each way) will be sized when the town approaches them.",
+      "target": 5,
+      "ladder": "5:5,10:10",
+      "reward": "5 stamps to each of you at 5 each way; 10 each at 10",
+      "resets": "never — a milestone is earned once per pair per rung, and kept"
     }
   ]
 }

--- a/tools/quest-progress.mjs
+++ b/tools/quest-progress.mjs
@@ -18,6 +18,7 @@ import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   parseDeliveries, householdKeys, parseStampLedger, parseLaws, deriveMints, meepChecker,
+  foldPairFriendships,
 } from './stamp-mint.mjs';
 
 // "today" = the mint rule's day boundary (TOWN_TZ), never the server clock —
@@ -87,6 +88,45 @@ export function foldQuestProgress(repo, { today = townDay() } = {}) {
   return out;
 }
 
+// The milestone fold (quest gold, budding-friendship). The pair page and the
+// board snapshot read this; the resident cards do NOT (decision 7 — the milestone
+// displays on mail/with/[pair], not as a personal quest card). Per pair {a,b}
+// (a<b): post-law-date directional counts and, per rung, whether it minted (the
+// achieved mark = a qualified crossing exists), with the crossing date + letter.
+// `qualifies` is "could this pair ever mint, as of now" (cross-household + both
+// non-meep) — the pair page shows the block only when true, so a meep or same-
+// roof pair never sees a progress bar toward an award it cannot earn. Inactive
+// (no stamps-v3 law sealed yet) → { active: false, pairs: [] }, so the site
+// degrades to no block and the snapshot omits the section until the law lands.
+export function foldFriendships(repo) {
+  const deliveries = parseDeliveries(repo);
+  const households = householdKeys(repo);
+  const ledgerPath = join(repo, 'WHITE_PAGES', 'stamp-ledger.md');
+  const entries = existsSync(ledgerPath) ? parseStampLedger(readFileSync(ledgerPath, 'utf8')) : [];
+  const { laws, revisions } = parseLaws(entries);
+  const { active, startDate, ladder, pairs } = foldPairFriendships(deliveries, households, { laws, revisions });
+  if (!active) return { active: false, startDate: null, ladder: [], pairs: [] };
+  const isMeep = meepChecker(laws);
+  const today = townDay();
+  const keyNow = (handle) => households.get(handle)?.key ?? `solo:${handle}`;
+  const out = [];
+  for (const st of pairs.values()) {
+    const crossingBy = new Map(st.crossings.map((c) => [c.threshold, c]));
+    const rungs = ladder.map((r) => {
+      const c = crossingBy.get(r.threshold);
+      const achieved = !!(c && c.qualified);
+      return {
+        threshold: r.threshold, reward: r.reward, achieved,
+        date: achieved ? c.date : null, via: achieved ? c.viaId : null,
+      };
+    });
+    const qualifies = !isMeep(st.a, today) && !isMeep(st.b, today) && keyNow(st.a) !== keyNow(st.b);
+    out.push({ a: st.a, b: st.b, fwd: st.fwd, rev: st.rev, eachWay: Math.min(st.fwd, st.rev), qualifies, rungs });
+  }
+  out.sort((x, y) => x.a.localeCompare(y.a) || x.b.localeCompare(y.b));
+  return { active: true, startDate, ladder, pairs: out };
+}
+
 // The board for ONE handle: registry × this handle's progress. The shape the
 // office API returns and the resident page renders. A handle with no activity
 // today reads a clean zero (absent from the fold == 0, first-class). PURE join
@@ -99,7 +139,10 @@ export function boardForHandle(registry, prog, handle, today) {
   // which correspondents already counted today, per direction. Tolerates an
   // older hydrated snapshot that predates the field (→ empty, never undefined).
   const withField = { 'correspond-send': 'sentTo', 'correspond-receive': 'heardFrom' };
-  const quests = registry.quests.map((q) => {
+  // Milestone quests (the budding-friendship pair achievement) render on the pair
+  // page, NEVER as a personal quest card (decision 7). The resident board is the
+  // daily quests only.
+  const quests = registry.quests.filter((q) => q.cadence !== 'milestone').map((q) => {
     const f = field[q.id];
     const done = f ? p[f] : 0;
     const houseTotal = f ? p.household[f] : 0;
@@ -108,7 +151,7 @@ export function boardForHandle(registry, prog, handle, today) {
     const capShared = p.household.size > 1 && houseTotal >= q.target;
     return {
       id: q.id, title: q.title, cadence: q.cadence, validation: q.validation,
-      target: q.target, reward: q.reward,
+      target: q.target, reward: q.reward, source: q.source,
       progress: done, complete: done >= q.target,
       counted: (p[withField[q.id]] ?? []).slice(),
       household: { size: p.household.size, total: houseTotal, cap_shared: capShared },
@@ -174,6 +217,35 @@ export function foldLeaderboard(repo, { today = townDay(), registry = loadRegist
 export function renderSnapshot(repo, { today = townDay(), registry = loadRegistry(repo) } = {}) {
   const { rows, totalCompletionsToday, sendTgt, recvTgt } = foldLeaderboard(repo, { today, registry });
   const cell = (v, t) => (v >= t ? `${v}/${t} ✓` : `${v}/${t}`);
+
+  // Budding friendships (the milestone). Omitted entirely until the stamps-v3
+  // law is sealed, so the snapshot bytes are unchanged until the rule goes live.
+  // Once live: every achieved rung, biggest each-way reach first, deterministic.
+  const friendships = foldFriendships(repo);
+  const friendshipBlock = (() => {
+    if (!friendships.active) return '';
+    const achieved = [];
+    for (const p of friendships.pairs) {
+      for (const r of p.rungs) {
+        if (r.achieved) achieved.push({ a: p.a, b: p.b, threshold: r.threshold, reward: r.reward, date: r.date });
+      }
+    }
+    achieved.sort((x, y) => y.threshold - x.threshold || x.date.localeCompare(y.date) || x.a.localeCompare(y.a) || x.b.localeCompare(y.b));
+    const rungWords = friendships.ladder.map((r) => `${r.threshold} each way mints ${r.reward} to each`).join('; ');
+    const table = achieved.length
+      ? ['| pair | reached | minted each | when |', '|---|---|---|---|',
+         ...achieved.map((c) => `| ${c.a} & ${c.b} | ${c.threshold} letters each way | ${c.reward} | ${c.date} |`)].join('\n')
+      : '_No budding friendship has crossed a rung yet._';
+    return `## Budding friendships
+
+A correspondence that *continued* — the town's fourth earning rule (${rungWords}), forward
+from ${friendships.startDate}, once per pair per rung, across two households, no meeps. Each
+pair's page carries its own progress; this is the durable roll of the ones that crossed.
+
+${table}
+
+`;
+  })();
   const body = rows.length
     ? rows.map((r, i) => `| ${i + 1} | ${r.handle} | ${cell(r.todaySend, sendTgt)} | ${cell(r.todayReceive, recvTgt)} | ${r.completionsToday} | ${r.allTime} |`).join('\n')
     : '| — | _no questing yet today_ | — | — | — | — |';
@@ -194,7 +266,7 @@ ${body}
 _As of ledger day **${today}**. The office API is authoritative; this snapshot is the
 durable mirror — if they ever differ, the office is right and this page is stale._
 
-## The rules
+${friendshipBlock}## The rules
 
 Two daily quests give the **existing correspondence mint** two visible faces — no new
 stamp is minted for them; they name what already earns. **Reach out** — send to ${sendTgt}

--- a/tools/quest-progress.test.mjs
+++ b/tools/quest-progress.test.mjs
@@ -129,8 +129,13 @@ test('live ledger: every handle within [0, target], flags consistent', () => {
     }
     const board = questBoard(REPO, handle, { progress: prog });
     for (const q of board.quests) assert.equal(q.complete, q.progress >= q.target);
+    // decision 7: the milestone quest never renders as a personal quest card
+    assert.ok(board.quests.every((q) => q.cadence !== 'milestone'), `${handle} board shows a milestone card`);
+    assert.equal(board.quests.length, 2, 'resident cards are the two dailies only');
   }
-  assert.equal(reg.quests.length, 2);
+  // registry now carries the two dailies + the correspond-depth milestone
+  assert.equal(reg.quests.length, 3);
+  assert.ok(reg.quests.some((q) => q.id === 'correspond-depth' && q.cadence === 'milestone'));
 });
 
 // ── `counted`: who already filled a unit today (the quest-card affordance) ────

--- a/tools/stamp-friendship.test.mjs
+++ b/tools/stamp-friendship.test.mjs
@@ -1,0 +1,243 @@
+// stamp-friendship.test.mjs — the fourth earning rule: budding-friendship
+// milestone (stamps-v3). Threshold, reward, forward-only, cross-household,
+// non-meep, both-or-neither, once-per-rung, the ladder, the parity gate, CRLF,
+// and forgery.
+//   node --test tools/stamp-friendship.test.mjs
+// Gold plan: postmark-budding-friendship. Zero-dep; throwaway repos + ed25519.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { generateKeyPairSync } from 'node:crypto';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { parseStampLedger, foldBalances, classifyEntry } from './stamp-mint.mjs';
+import { verifyStampLedger } from './stamp-verify.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function town({ ledgerLines, pins = {}, addresses = {} }) {
+  const repo = mkdtempSync(join(tmpdir(), 'stamp-town-friend-'));
+  mkdirSync(join(repo, 'tools'), { recursive: true });
+  mkdirSync(join(repo, 'WHITE_PAGES'), { recursive: true });
+  writeFileSync(join(repo, 'tools', 'github-ids.json'), JSON.stringify(pins));
+  for (const [handle, github] of Object.entries(addresses)) {
+    mkdirSync(join(repo, 'WHITE_PAGES', handle), { recursive: true });
+    writeFileSync(join(repo, 'WHITE_PAGES', handle, 'ADDRESS.md'),
+      `---\nhandle: ${handle}\n${github ? `github: ${github}\n` : ''}---\n`);
+  }
+  writeFileSync(join(repo, 'WHITE_PAGES', 'mail-ledger.md'), `# ledger\n\n${ledgerLines.join('\n')}\n`);
+  return repo;
+}
+
+const D = (date, id, from, to) => `- ${date} · ${id} · ${from} → ${to} · thread: new`;
+
+function keypair() {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  return {
+    pub: publicKey.export({ type: 'spki', format: 'pem' }),
+    priv: privateKey.export({ type: 'pkcs8', format: 'pem' }),
+  };
+}
+function keyFile(repo, priv) { const f = join(repo, 'stamp-key.pem'); writeFileSync(f, priv); return f; }
+function mintPass(repo, priv) {
+  execFileSync(process.execPath, [join(HERE, 'stamp-mint.mjs'), '--append', '--key', keyFile(repo, priv), '--repo', repo], { encoding: 'utf8' });
+}
+function declareV3(repo, priv, date, meeps, ladder = '5:5,10:10') {
+  execFileSync(process.execPath, [join(HERE, 'stamp-mint.mjs'), '--declare-rules', 'stamps-v3',
+    '--meeps', meeps.join(','), '--friendship', ladder, '--date', date, '--key', keyFile(repo, priv), '--repo', repo], { encoding: 'utf8' });
+}
+const ledgerText = (repo) => readFileSync(join(repo, 'WHITE_PAGES', 'stamp-ledger.md'), 'utf8');
+const balancesOf = (repo) => foldBalances(parseStampLedger(ledgerText(repo)));
+const friendshipLines = (repo) =>
+  parseStampLedger(ledgerText(repo)).map((e) => classifyEntry(e.canonical)).filter((c) => c.kind === 'friendship');
+
+// n letters each way between a and b, one letter per distinct day starting at
+// `startDay` of `month`, a→b first then b→a. Returns the lines and the id of the
+// delivery that crosses (the last b→a, which lifts min(fwd,rev) to n).
+function eachWay(a, b, n, month, startDay, tag) {
+  const lines = [];
+  let day = startDay;
+  for (let i = 1; i <= n; i++) lines.push(D(`2026-${month}-${String(day++).padStart(2, '0')}`, `${tag}-ab-${i}`, a, b));
+  let crossId = null;
+  for (let i = 1; i <= n; i++) { crossId = `${tag}-ba-${i}`; lines.push(D(`2026-${month}-${String(day++).padStart(2, '0')}`, crossId, b, a)); }
+  return { lines, crossId };
+}
+
+// ── the ruled decisions ───────────────────────────────────────────────────────
+
+test('friendship: cross-household non-meeps mint 5 each at 5 letters each way, via the crossing letter', () => {
+  const { pub, priv } = keypair();
+  const repo = town({ ledgerLines: [D('2026-06-12', 'seed', 'alice', 'bob')], addresses: { alice: 'alogin', bob: 'blogin' } });
+  writeFileSync(join(repo, 'tools', 'stamp-pubkey.pem'), pub);
+  mintPass(repo, priv);
+  declareV3(repo, priv, '2026-06-20', ['somebot']);            // meep set carried forward (none in this pair)
+
+  const { lines, crossId } = eachWay('alice', 'bob', 5, '06', 21, 'r1');
+  const ml = join(repo, 'WHITE_PAGES', 'mail-ledger.md');
+  writeFileSync(ml, readFileSync(ml, 'utf8') + lines.join('\n') + '\n');
+  mintPass(repo, priv);
+
+  const r = verifyStampLedger(repo);
+  assert.equal(r.ok, true, r.problems.join('; '));
+  const fm = friendshipLines(repo);
+  assert.equal(fm.length, 2, 'exactly two friendship mints — one per side, both or neither');
+  const byHandle = new Map(fm.map((m) => [m.handle, m]));
+  assert.equal(byHandle.get('alice').n, 5); assert.equal(byHandle.get('alice').friendWith, 'bob');
+  assert.equal(byHandle.get('bob').n, 5); assert.equal(byHandle.get('bob').friendWith, 'alice');
+  assert.equal(byHandle.get('alice').cause, crossId, 'via = the letter that crossed the 5-each-way floor');
+  const bal = balancesOf(repo);
+  // seed(06-12) alice→bob mints BOTH sides (+1 alice sent, +1 bob received). Then
+  // the each-way block: each of alice/bob sends 5 (distinct days) and receives 5 →
+  // +10 each. So 11 correspondence each + 5 friendship each = 16.
+  assert.equal(bal.get('alice'), 16, 'alice: 11 correspondence + 5 friendship');
+  assert.equal(bal.get('bob'), 16, 'bob: 11 correspondence + 5 friendship');
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test('friendship: the ladder — +10 at 10 each way, once per rung, no re-mint of the 5-rung', () => {
+  const { pub, priv } = keypair();
+  const repo = town({ ledgerLines: [D('2026-06-12', 'seed', 'alice', 'bob')], addresses: { alice: 'alogin', bob: 'blogin' } });
+  writeFileSync(join(repo, 'tools', 'stamp-pubkey.pem'), pub);
+  mintPass(repo, priv);
+  declareV3(repo, priv, '2026-06-20', ['somebot']);
+  const ml = join(repo, 'WHITE_PAGES', 'mail-ledger.md');
+
+  // 5 each way → the 5-rung
+  writeFileSync(ml, readFileSync(ml, 'utf8') + eachWay('alice', 'bob', 5, '06', 21, 'a').lines.join('\n') + '\n');
+  mintPass(repo, priv);
+  assert.equal(friendshipLines(repo).length, 2, 'the 5-rung minted once (2 lines)');
+
+  // 5 more each way → 10 each way, the 10-rung; the 5-rung must NOT re-fire
+  const more = eachWay('alice', 'bob', 5, '07', 1, 'b');   // July, distinct days
+  writeFileSync(ml, readFileSync(ml, 'utf8') + more.lines.join('\n') + '\n');
+  mintPass(repo, priv);
+
+  const r = verifyStampLedger(repo);
+  assert.equal(r.ok, true, r.problems.join('; '));
+  const fm = friendshipLines(repo);
+  assert.equal(fm.length, 4, 'two rungs crossed → four friendship mints, never more');
+  const tens = fm.filter((m) => m.n === 10);
+  assert.equal(tens.length, 2, 'the 10-rung mints 10 to each');
+  assert.equal(tens.every((m) => m.cause === more.crossId), true, 'the 10-rung via = the 10th-each-way letter');
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test('friendship: FORWARD-ONLY — a pair already at 5+ each way before the law mints nothing', () => {
+  const { pub, priv } = keypair();
+  // alice & bob reach 5 each way entirely in June, all BEFORE the law date.
+  const pre = eachWay('alice', 'bob', 6, '06', 1, 'pre'); // 6 each way, pre-law
+  const repo = town({ ledgerLines: pre.lines, addresses: { alice: 'alogin', bob: 'blogin' } });
+  writeFileSync(join(repo, 'tools', 'stamp-pubkey.pem'), pub);
+  mintPass(repo, priv);
+  const preLaw = ledgerText(repo);                        // the byte-for-byte pre-law ledger
+
+  declareV3(repo, priv, '2026-06-30', ['somebot']);       // law AFTER all their correspondence
+  mintPass(repo, priv);                                   // no post-law deliveries → nothing to mint
+
+  const r = verifyStampLedger(repo);
+  assert.equal(r.ok, true, r.problems.join('; '));
+  assert.equal(friendshipLines(repo).length, 0, 'their whole history predates the law — zero friendship mints');
+  // PARITY GATE: every pre-law line is byte-identical; the v3 line is the only addition.
+  const after = ledgerText(repo);
+  assert.equal(after.startsWith(preLaw), true, 'pre-law ledger is byte-identical — the rule did not leak backward');
+  assert.ok(after.slice(preLaw.length).includes('rules: stamps-v3'), 'only the v3 law line was appended');
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test('friendship: forward-only counts restart at the law — pre-law letters do not seed the post-law tally', () => {
+  const { pub, priv } = keypair();
+  const pre = eachWay('alice', 'bob', 4, '06', 1, 'pre');  // 4 each way pre-law
+  const repo = town({ ledgerLines: pre.lines, addresses: { alice: 'alogin', bob: 'blogin' } });
+  writeFileSync(join(repo, 'tools', 'stamp-pubkey.pem'), pub);
+  mintPass(repo, priv);
+  declareV3(repo, priv, '2026-06-30', ['somebot']);
+  const ml = join(repo, 'WHITE_PAGES', 'mail-ledger.md');
+
+  // 4 more each way post-law → post-law each-way count is 4, NOT 4+4=8. No 5-rung.
+  writeFileSync(ml, readFileSync(ml, 'utf8') + eachWay('alice', 'bob', 4, '07', 1, 'post').lines.join('\n') + '\n');
+  mintPass(repo, priv);
+  assert.equal(friendshipLines(repo).length, 0, 'pre-law letters are not counted — post-law is only 4 each way');
+
+  // one more each way post-law → now 5 each way post-law → the 5-rung fires
+  writeFileSync(ml, readFileSync(ml, 'utf8') + eachWay('alice', 'bob', 1, '07', 20, 'post5').lines.join('\n') + '\n');
+  mintPass(repo, priv);
+  assert.equal(friendshipLines(repo).length, 2, 'the 5th post-law each-way letter crosses the rung');
+  assert.equal(verifyStampLedger(repo).ok, true);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test('friendship: same-household pair does NOT mint (cross-household required)', () => {
+  const { pub, priv } = keypair();
+  const repo = town({
+    ledgerLines: [D('2026-06-12', 'seed', 'alice', 'bob')],
+    pins: { alice: { login: 'k', id: 7 }, bob: { login: 'k', id: 7 } },   // one household
+  });
+  writeFileSync(join(repo, 'tools', 'stamp-pubkey.pem'), pub);
+  mintPass(repo, priv);
+  declareV3(repo, priv, '2026-06-20', ['somebot']);
+  const ml = join(repo, 'WHITE_PAGES', 'mail-ledger.md');
+  writeFileSync(ml, readFileSync(ml, 'utf8') + eachWay('alice', 'bob', 6, '06', 21, 'x').lines.join('\n') + '\n');
+  mintPass(repo, priv);
+  assert.equal(verifyStampLedger(repo).ok, true);
+  assert.equal(friendshipLines(repo).length, 0, 'same roof — no friendship mint');
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test('friendship: a meep on either side excludes the pair — neither mints (the deliberate divergence)', () => {
+  const { pub, priv } = keypair();
+  const repo = town({ ledgerLines: [D('2026-06-12', 'seed', 'alice', 'meepy')], addresses: { alice: 'alogin', meepy: 'mlogin' } });
+  writeFileSync(join(repo, 'tools', 'stamp-pubkey.pem'), pub);
+  mintPass(repo, priv);
+  declareV3(repo, priv, '2026-06-20', ['meepy']);          // meepy is a declared meep
+  const ml = join(repo, 'WHITE_PAGES', 'mail-ledger.md');
+  writeFileSync(ml, readFileSync(ml, 'utf8') + eachWay('alice', 'meepy', 6, '06', 21, 'm').lines.join('\n') + '\n');
+  mintPass(repo, priv);
+  assert.equal(verifyStampLedger(repo).ok, true);
+  assert.equal(friendshipLines(repo).length, 0, 'no meeps allowed — the non-meep side does not mint either');
+  rmSync(repo, { recursive: true, force: true });
+});
+
+// ── integrity: the gate the plan cares about ─────────────────────────────────
+
+test('friendship: a forged friendship line has no mail behind it — REPLAY turns red', () => {
+  const { pub, priv } = keypair();
+  const repo = town({ ledgerLines: [D('2026-06-12', 'seed', 'alice', 'bob')], addresses: { alice: 'alogin', bob: 'blogin' } });
+  writeFileSync(join(repo, 'tools', 'stamp-pubkey.pem'), pub);
+  mintPass(repo, priv);
+  declareV3(repo, priv, '2026-06-20', ['somebot']);
+  // hand-insert a friendship mint that never crossed a real threshold (and forge a sig)
+  const p = join(repo, 'WHITE_PAGES', 'stamp-ledger.md');
+  writeFileSync(p, readFileSync(p, 'utf8') + '- 2026-06-25 · MINT → alice · 5 · for: friendship:bob (via ghost) · sig: AAAA\n');
+  const r = verifyStampLedger(repo);
+  assert.equal(r.ok, false, 'a friendship stamp with no mail behind it must not verify');
+  assert.ok(r.problems.some((x) => x.includes('SIGNATURE FAILS') || x.includes('REPLAY') || x.includes('beyond the derivation')), r.problems.join('; '));
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test('friendship: CRLF mail-ledger folds correctly (the plan\'s documented parsing hazard)', () => {
+  const { pub, priv } = keypair();
+  const repo = town({ ledgerLines: [D('2026-06-12', 'seed', 'alice', 'bob')], addresses: { alice: 'alogin', bob: 'blogin' } });
+  writeFileSync(join(repo, 'tools', 'stamp-pubkey.pem'), pub);
+  mintPass(repo, priv);
+  declareV3(repo, priv, '2026-06-20', ['somebot']);
+  // rewrite the WHOLE mail-ledger with CRLF line endings, then add the crossing block (also CRLF)
+  const ml = join(repo, 'WHITE_PAGES', 'mail-ledger.md');
+  const withBlock = readFileSync(ml, 'utf8') + eachWay('alice', 'bob', 5, '06', 21, 'crlf').lines.join('\n') + '\n';
+  writeFileSync(ml, withBlock.replace(/\n/g, '\r\n'));
+  mintPass(repo, priv);
+  assert.equal(verifyStampLedger(repo).ok, true, 'CRLF ledger still verifies');
+  assert.equal(friendshipLines(repo).length, 2, 'CRLF did not mis-key the crossing letter — the pair minted');
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test('friendship: retroactive v3 declaration is refused (must be forward-dated)', () => {
+  const { pub, priv } = keypair();
+  const repo = town({ ledgerLines: [D('2026-06-25', 'seed', 'alice', 'bob')], addresses: { alice: 'alogin', bob: 'blogin' } });
+  writeFileSync(join(repo, 'tools', 'stamp-pubkey.pem'), pub);
+  mintPass(repo, priv);
+  assert.throws(() => declareV3(repo, priv, '2026-06-25', ['somebot']), 'a law dated at/behind the last delivery is refused');
+  rmSync(repo, { recursive: true, force: true });
+});

--- a/tools/stamp-mint.mjs
+++ b/tools/stamp-mint.mjs
@@ -20,6 +20,7 @@
 //   - <date> · <sender> → <recipient> · <n> · via: mail:<letter-id> · sig: <...>   (transfer — LIVE under the `pays:` blessing, stamps-spend silver 2026-07-14; a delivered letter carrying `pays: N` moves N sender→recipient)
 //   - <date> · void · mail:<letter-id> · from <sender> to <recipient> · <n> · <reason> · sig: <...>   (a `pays:` that could not settle — moves nothing; reason ∈ {insufficient-balance, meep-party, self-pay})
 //   - <date> · MINT → <handle> · <n> · for: gift:<slug> · by: <founder>   (founder gift — case-by-case award, principal-blessed 2026-07-18; drawn from MINT like any mint, recipient never a meep)
+//   - <date> · MINT → <handle> · <n> · for: friendship:<other> (via <letter-id>)   (stamps-v3 budding-friendship milestone — a DERIVED mint that rides the replay; both sides of a qualifying pair, forward-only from the v3 law date)
 //   - <date> · <handle> → BURN · <n> · ...        (reserved; dormant until blessings)
 // Every entry is a two-sided movement — conservation is structural (entries
 // sum to zero against the MINT/BURN accounts); a balance is a pure fold, and
@@ -58,12 +59,23 @@
 //      VOIDS with an honest ledger note and the letter still delivered. A
 //      `pays:` to or from a meep handle voids too — meeps stay outside the
 //      currency. Voids move nothing; conservation is untouched.
+//   7. stamps-v3 (budding-friendship milestone, 2026-07-22, gold plan postmark-
+//      budding-friendship): when a CROSS-HOUSEHOLD pair of NON-meep handles
+//      reaches a rung threshold in BOTH directions — 5 each way, then 10; the
+//      ladder is pinned in the v3 law line — counting ONLY deliveries on/after the
+//      v3 law date, mint the rung's reward to BOTH sides, once per pair per rung.
+//      Both sides mint or neither does — the deliberate divergence from rule 5
+//      ("no meeps allowed", Keemin). A DERIVED mint: recomputable from the mail, it
+//      rides the replay subsequence, so a forged friendship stamp turns the replay
+//      red like any other. Forward-only is structural — no v3 law recorded, no
+//      friendship mint, so the engine is inert until the office pen seals the line.
 //
 // Usage:
 //   node tools/stamp-mint.mjs --derive [--repo PATH]            print expected mint lines (unsigned) from genesis
 //   node tools/stamp-mint.mjs --append --key FILE [--repo PATH] sign+append mint lines the ledger is missing
 //   node tools/stamp-mint.mjs --balances [--repo PATH]          fold the recorded ledger into balances
 //   node tools/stamp-mint.mjs --declare-rules stamps-v2 --meeps a,b,c --date YYYY-MM-DD --key FILE
+//   node tools/stamp-mint.mjs --declare-rules stamps-v3 --meeps a,b,c --friendship 5:5,10:10 --date YYYY-MM-DD --key FILE
 //   node tools/stamp-mint.mjs --declare-registry "handle = gh:ID" --date YYYY-MM-DD --key FILE
 //   node tools/stamp-mint.mjs --gift <handle> --amount N --slug <kebab-reason> --by <founder> --date YYYY-MM-DD --key FILE
 //
@@ -81,8 +93,23 @@ const RULES_V1 = 'stamps-v1';
 const GENESIS_SEAL_SEED = 'postmark-stamps-v1';
 const CAP_SENDS = 5;
 const CAP_RECEIVES = 5;
+// stamps-v3 (budding-friendship milestone): the default rung ladder the office
+// pen declares. "threshold:reward" per rung, each way, once per pair per rung.
+// The held 50/100 rungs are deliberately NOT here — adding a rung is a dated law
+// event (a new --declare-rules stamps-v3 line), never a silent code change, so a
+// later rung can never mint retroactively (gold plan postmark-budding-friendship).
+const FRIENDSHIP_LADDER_V3 = '5:5,10:10';
 
 export const sha256hex = (s) => createHash('sha256').update(s, 'utf8').digest('hex');
+
+// "5:5,10:10" -> [{ threshold: 5, reward: 5 }, { threshold: 10, reward: 10 }], ascending.
+export function parseLadder(spec) {
+  return (spec ?? '').split(',').filter(Boolean)
+    .map((r) => { const [t, w] = r.split(':').map(Number); return { threshold: t, reward: w }; })
+    .filter((r) => Number.isInteger(r.threshold) && r.threshold > 0 && Number.isInteger(r.reward) && r.reward > 0)
+    .sort((a, b) => a.threshold - b.threshold);
+}
+export const serializeLadder = (ladder) => ladder.map((r) => `${r.threshold}:${r.reward}`).join(',');
 
 // ── mail-ledger parsing (same grammar as ferry.mjs / reconcile.mjs) ─────────
 
@@ -146,7 +173,10 @@ export function householdKeys(repo) {
 
 // ── ledger line classification (laws, revisions, mints, stakes) ─────────────
 
-const RULES_RE = /^- (\d{4}-\d{2}-\d{2}) · rules: (\S+)(?: · meeps: (\S+))?$/;
+// The optional ` · friendship: <ladder>` segment (stamps-v3) sits at the tail,
+// AFTER the optional meeps segment. v1/v2 lines have neither trailing group and
+// parse byte-identically — the parity gate depends on that.
+const RULES_RE = /^- (\d{4}-\d{2}-\d{2}) · rules: (\S+)(?: · meeps: (\S+))?(?: · friendship: (\S+))?$/;
 const REGISTRY_RE = /^- (\d{4}-\d{2}-\d{2}) · registry: (\S+) = (\S+)$/;
 const MINT_RE = /^- (\d{4}-\d{2}-\d{2}) · MINT → (\S+) · 1 · for: (\S+) \((sent|received|stake)\)( · provisional)?$/;
 // Candidate class is [A-Za-z0-9-]: ballot law says "stake the exact candidate
@@ -165,11 +195,18 @@ const VOID_RE = /^- (\d{4}-\d{2}-\d{2}) · void · mail:(\S+) · from (\S+) to (
 // A gift IS movement-shaped (MINT → handle) so conservation folds it structurally;
 // it cannot collide with MINT_RE (no `(side)` suffix, `· by:` tail, n may exceed 1).
 const GIFT_RE = /^- (\d{4}-\d{2}-\d{2}) · MINT → (\S+) · ([1-9]\d*) · for: gift:([a-z0-9][a-z0-9-]*) · by: (\S+)$/;
+// A friendship mint (stamps-v3) is ALSO movement-shaped (MINT → handle · n), so
+// conservation folds it structurally. It cannot collide with MINT_RE (n > 1 and
+// `for: friendship:… (via …)` not `(sent|received|stake)`) or GIFT_RE
+// (`for: friendship:` not `for: gift:`). Unlike a gift, it is a DERIVED mint —
+// recomputable from the mail — so it rides the replay subsequence, not the
+// in-place assertion lane. `<other>` is a handle, `<letter-id>` the crossing.
+const FRIENDSHIP_RE = /^- (\d{4}-\d{2}-\d{2}) · MINT → (\S+) · ([1-9]\d*) · for: friendship:(\S+) \(via (\S+)\)$/;
 
 export function classifyEntry(canonical) {
   let m;
   if ((m = RULES_RE.exec(canonical)))
-    return { kind: 'rules', date: m[1], rules: m[2], meeps: m[3] ? m[3].split(',') : [] };
+    return { kind: 'rules', date: m[1], rules: m[2], meeps: m[3] ? m[3].split(',') : [], friendship: m[4] ? parseLadder(m[4]) : null };
   if ((m = REGISTRY_RE.exec(canonical)))
     return { kind: 'registry', date: m[1], handle: m[2], key: m[3] };
   if ((m = MINT_RE.exec(canonical))) {
@@ -185,6 +222,8 @@ export function classifyEntry(canonical) {
     return { kind: 'void', date: m[1], id: m[2], from: m[3], to: m[4], n: Number(m[5]), reason: m[6] };
   if ((m = GIFT_RE.exec(canonical)))
     return { kind: 'gift', date: m[1], handle: m[2], n: Number(m[3]), slug: m[4], by: m[5] };
+  if ((m = FRIENDSHIP_RE.exec(canonical)))
+    return { kind: 'friendship', date: m[1], handle: m[2], n: Number(m[3]), friendWith: m[4], cause: m[5] };
   if ((m = TRANSFER_RE.exec(canonical)))
     return { kind: 'transfer', date: m[1], from: m[2], to: m[3], n: Number(m[4]), id: m[5] };
   return { kind: 'unknown' };
@@ -196,7 +235,7 @@ export function parseLaws(entries) {
   const revisions = []; // [{date, handle, key}]
   for (const e of entries) {
     const c = classifyEntry(e.canonical);
-    if (c.kind === 'rules') laws.push({ date: c.date, rules: c.rules, meeps: new Set(c.meeps) });
+    if (c.kind === 'rules') laws.push({ date: c.date, rules: c.rules, meeps: new Set(c.meeps), friendship: c.friendship ?? null });
     if (c.kind === 'registry') revisions.push({ date: c.date, handle: c.handle, key: c.key });
   }
   return { laws, revisions };
@@ -234,8 +273,9 @@ export function deriveMints(deliveries, households, { laws = [], revisions = [] 
     dayCount.set(capKey, n + 1);
     // `other` is the correspondent this mint was earned WITH. Carried for the
     // quest cards ("who already counted today"), never for the ledger — mintLine
-    // builds from named fields, so this cannot change a ledger byte.
-    mints.push({ date: d.date, handle, side, other, cause: d.id, provisional: h.provisional });
+    // builds from named fields, so this cannot change a ledger byte. `kind` lets
+    // the combined derived stream tell a correspondence mint from a friendship one.
+    mints.push({ kind: 'mint', date: d.date, handle, side, other, cause: d.id, provisional: h.provisional });
   };
 
   for (const d of deliveries) {
@@ -243,6 +283,93 @@ export function deriveMints(deliveries, households, { laws = [], revisions = [] 
     trySide('received', d.to, d.from, d);
   }
   return mints;
+}
+
+// ── the fourth earning rule: budding-friendship milestone (stamps-v3) ─────────
+// A per-pair ordered fold over deliveries. Forward-only is structural: only the
+// stamps-v3 law's `friendship:` ladder and date drive it, so with no v3 law
+// recorded this returns nothing and the engine is inert on the pre-law ledger —
+// which is exactly what leaves the pre-law replay byte-identical (gold plan
+// postmark-budding-friendship § the parity gate). Reuses the deliveries parsed
+// upstream (CRLF-safe); it never re-parses the ledger.
+//
+// foldPairFriendships is the ONE crossing authority — both the mint
+// (deriveFriendshipMints) and the display fold (quest-progress foldFriendships)
+// read it, so the "both directions reached rung R" logic has a single home.
+// Per pair {a,b} (a<b lexicographically): fwd = a→b deliveries, rev = b→a, both
+// counted only on/after the law date. A rung crosses the first time min(fwd,rev)
+// steps up to the rung's threshold (min moves by ≤1 per delivery, so each rung
+// crosses exactly once, ever). Gates are read AT the crossing delivery: both
+// sides non-meep AND cross-household. Both sides qualify together or neither does.
+export function foldPairFriendships(deliveries, households, { laws = [], revisions = [] } = {}) {
+  const friendshipLaws = laws.filter((l) => l.friendship && l.friendship.length)
+    .sort((a, b) => a.date.localeCompare(b.date));
+  if (!friendshipLaws.length) return { active: false, startDate: null, ladder: [], pairs: new Map() };
+  const active = friendshipLaws[0]; // v3; extending the ladder later is a deferred, dated event (held 50/100 rungs)
+  const startDate = active.date;
+  const ladder = active.friendship;
+  const isMeep = meepChecker(laws);
+  const hh = (handle, date) => {
+    let key = households.get(handle)?.key ?? `solo:${handle}`;
+    for (const r of revisions) if (r.handle === handle && r.date <= date) key = r.key;
+    return key;
+  };
+  const pairs = new Map(); // "a|b" -> { a, b, fwd, rev, min, crossings:[{threshold,reward,date,viaId,qualified}] }
+  for (const d of deliveries) {
+    if (d.date < startDate || d.from === d.to) continue; // forward-only; self-mail is not a correspondence
+    const [a, b] = [d.from, d.to].sort();
+    const key = `${a}|${b}`;
+    let st = pairs.get(key);
+    if (!st) { st = { a, b, fwd: 0, rev: 0, min: 0, crossings: [] }; pairs.set(key, st); }
+    if (d.from === a) st.fwd++; else st.rev++;
+    const prevMin = st.min;
+    const newMin = Math.min(st.fwd, st.rev);
+    st.min = newMin;
+    if (newMin === prevMin) continue; // this delivery lengthened the longer side only — no new floor
+    const rung = ladder.find((r) => r.threshold === newMin);
+    if (!rung) continue;
+    const qualified = !isMeep(a, d.date) && !isMeep(b, d.date) && hh(a, d.date) !== hh(b, d.date);
+    st.crossings.push({ threshold: rung.threshold, reward: rung.reward, date: d.date, viaId: d.id, qualified });
+  }
+  return { active: true, startDate, ladder, pairs };
+}
+
+// The mint objects the fourth rule produces: two per qualified rung crossing
+// (both sides, same reward, same crossing letter), smaller handle first. Sorted
+// by (date, cause, handle) so the order is canonical; combineDerived re-buckets
+// them by delivery id, so this order only settles the within-crossing pair order.
+export function deriveFriendshipMints(deliveries, households, opts = {}) {
+  const { pairs } = foldPairFriendships(deliveries, households, opts);
+  const out = [];
+  for (const st of pairs.values()) {
+    for (const c of st.crossings) {
+      if (!c.qualified) continue;
+      out.push({ kind: 'friendship', date: c.date, handle: st.a, n: c.reward, friendWith: st.b, cause: c.viaId });
+      out.push({ kind: 'friendship', date: c.date, handle: st.b, n: c.reward, friendWith: st.a, cause: c.viaId });
+    }
+  }
+  out.sort((x, y) => x.date.localeCompare(y.date) || x.cause.localeCompare(y.cause) || x.handle.localeCompare(y.handle));
+  return out;
+}
+
+// The full derived-mint stream in ledger order: for each delivery, its
+// correspondence mints (deriveMints order) then its friendship mints. This is
+// the single subsequence the recorded ledger's mint + friendship lines must
+// match, in order — walkLedger, the verifier, --append and --derive all key on it.
+export function combineDerived(deliveries, corrMints, friendshipMints) {
+  const byCause = (arr) => {
+    const m = new Map();
+    for (const x of arr) { if (!m.has(x.cause)) m.set(x.cause, []); m.get(x.cause).push(x); }
+    return m;
+  };
+  const corr = byCause(corrMints);
+  const friend = byCause(friendshipMints);
+  const out = [];
+  for (const d of deliveries) {
+    for (const m of (corr.get(d.id) ?? [])) out.push(m);
+    for (const m of (friend.get(d.id) ?? [])) out.push(m);
+  }
+  return out;
 }
 
 // ── settlement (`pays:`) — the ONE decision, shared by derive/append/verify ──
@@ -287,10 +414,18 @@ export function meepChecker(laws) {
 // and that replay share `settlementDecision`, so they cannot drift.
 export function deriveTransfers(deliveries, households, { laws = [], revisions = [] } = {}, assertionEntries = []) {
   const mints = deriveMints(deliveries, households, { laws, revisions });
-  const mintsById = new Map();
+  const friendMints = deriveFriendshipMints(deliveries, households, { laws, revisions });
+  // credits a delivery lands (its own mints) BEFORE its settlement, by amount:
+  // correspondence mints are 1, a friendship mint is its rung reward. All are
+  // added before the settlement decision, so order among them is irrelevant.
+  const creditsById = new Map();
   for (const m of mints) {
-    if (!mintsById.has(m.cause)) mintsById.set(m.cause, []);
-    mintsById.get(m.cause).push(m.handle);
+    if (!creditsById.has(m.cause)) creditsById.set(m.cause, []);
+    creditsById.get(m.cause).push({ handle: m.handle, amount: 1 });
+  }
+  for (const m of friendMints) {
+    if (!creditsById.has(m.cause)) creditsById.set(m.cause, []);
+    creditsById.get(m.cause).push({ handle: m.handle, amount: m.n });
   }
   const bal = new Map();
   const add = (acct, n) => bal.set(acct, (bal.get(acct) ?? 0) + n);
@@ -305,7 +440,7 @@ export function deriveTransfers(deliveries, households, { laws = [], revisions =
   const isMeep = meepChecker(laws);
   const out = [];
   for (const d of deliveries) {
-    for (const handle of (mintsById.get(d.id) ?? [])) add(handle, 1); // this letter's mints land first
+    for (const cr of (creditsById.get(d.id) ?? [])) add(cr.handle, cr.amount); // this letter's mints land first
     if (d.pays == null) continue;
     const decision = settlementDecision(d, bal.get(d.from) ?? 0, (h) => isMeep(h, d.date));
     if (decision.kind === 'transfer') { add(d.from, -d.pays); add(d.to, d.pays); }
@@ -319,10 +454,23 @@ export function deriveTransfers(deliveries, households, { laws = [], revisions =
 export const mintLine = (m) =>
   `- ${m.date} · MINT → ${m.handle} · 1 · for: ${m.cause} (${m.side})${m.provisional ? ' · provisional' : ''}`;
 
+export const friendshipMintLine = (m) =>
+  `- ${m.date} · MINT → ${m.handle} · ${m.n} · for: friendship:${m.friendWith} (via ${m.cause})`;
+
+// Correspondence mints and friendship mints are both DERIVED mints (recomputable
+// from mail) and share the walk/append/derive path; this renders either by kind.
+export const derivedLine = (m) => (m.kind === 'friendship' ? friendshipMintLine(m) : mintLine(m));
+
 export const rulesLine = (date) => `- ${date} · rules: ${RULES_V1}`;
 
 export const rulesV2Line = (date, meeps) =>
   `- ${date} · rules: stamps-v2 · meeps: ${[...meeps].sort().join(',')}`;
+
+// stamps-v3 restates the meep set (lawAt returns the single latest law, so the
+// set must carry forward or meeps would resume minting) AND opens the friendship
+// ladder. `ladderSpec` is a canonical "t:r,t:r" string (serializeLadder).
+export const rulesV3Line = (date, meeps, ladderSpec) =>
+  `- ${date} · rules: stamps-v3 · meeps: ${[...meeps].sort().join(',')} · friendship: ${ladderSpec}`;
 
 export const registryLine = (date, handle, key) => `- ${date} · registry: ${handle} = ${key}`;
 
@@ -442,12 +590,12 @@ export function foldStaked(entries) {
 
 export function walkLedger(recorded, derivedMints, offset = 0) {
   const problems = [];
-  const derivedCanonicals = derivedMints.map(mintLine);
+  const derivedCanonicals = derivedMints.map(derivedLine);
   let di = 0;
   for (let i = 0; i < recorded.length; i++) {
     const c = recorded[i];
     const cls = classifyEntry(c);
-    if (cls.kind === 'mint') {
+    if (cls.kind === 'mint' || cls.kind === 'friendship') {
       if (di >= derivedCanonicals.length) {
         problems.push(`line ${i + 1 + offset}: ledger mint beyond the derivation — a stamp with no mail behind it\n  recorded: ${c}`);
         break;
@@ -511,7 +659,7 @@ export function interleaveByDelivery(deliveries, mints, transfers) {
   const tById = new Map(transfers.map((t) => [t.id, t]));
   const lines = [];
   for (const d of deliveries) {
-    for (const m of (mById.get(d.id) ?? [])) lines.push(mintLine(m));
+    for (const m of (mById.get(d.id) ?? [])) lines.push(derivedLine(m));
     if (tById.has(d.id)) lines.push(economyLine(tById.get(d.id)));
   }
   return lines;
@@ -523,7 +671,9 @@ function loadState(repo) {
   const { laws, revisions } = parseLaws(existing);
   const deliveries = parseDeliveries(repo);
   const households = householdKeys(repo);
-  const mints = deriveMints(deliveries, households, { laws, revisions });
+  const corrMints = deriveMints(deliveries, households, { laws, revisions });
+  const friendMints = deriveFriendshipMints(deliveries, households, { laws, revisions });
+  const mints = combineDerived(deliveries, corrMints, friendMints); // the full derived subsequence
   const transfers = deriveTransfers(deliveries, households, { laws, revisions }, existing);
   return { ledgerPath, existing, laws, revisions, deliveries, mints, transfers };
 }
@@ -645,10 +795,20 @@ function main() {
     let canonical;
     if (has('--declare-rules')) {
       const name = arg('--declare-rules');
-      if (name !== 'stamps-v2') { console.error(`unknown rules version: ${name}`); process.exit(1); }
       const meeps = (arg('--meeps') ?? '').split(',').filter(Boolean);
-      if (!meeps.length) { console.error('--declare-rules stamps-v2 needs --meeps a,b,c'); process.exit(1); }
-      canonical = rulesV2Line(date, meeps);
+      if (name === 'stamps-v2') {
+        if (!meeps.length) { console.error('--declare-rules stamps-v2 needs --meeps a,b,c'); process.exit(1); }
+        canonical = rulesV2Line(date, meeps);
+      } else if (name === 'stamps-v3') {
+        // stamps-v3 opens the friendship ladder. It MUST restate the meep set
+        // (lawAt returns the latest law only — an empty meeps here would let meeps
+        // resume correspondence-minting from this date). The date guard below is
+        // what makes the rule forward-only: it must fall after the last delivery.
+        if (!meeps.length) { console.error('--declare-rules stamps-v3 needs --meeps a,b,c (carry the current meep set forward)'); process.exit(1); }
+        const ladder = parseLadder(arg('--friendship') ?? FRIENDSHIP_LADDER_V3);
+        if (!ladder.length) { console.error('--declare-rules stamps-v3 needs --friendship t:r,t:r (e.g. 5:5,10:10)'); process.exit(1); }
+        canonical = rulesV3Line(date, meeps, serializeLadder(ladder));
+      } else { console.error(`unknown rules version: ${name}`); process.exit(1); }
     } else {
       const m = /^(\S+)\s*=\s*(\S+)$/.exec(arg('--declare-registry') ?? '');
       if (!m) { console.error('--declare-registry needs "handle = key"'); process.exit(1); }
@@ -672,7 +832,7 @@ function main() {
     return;
   }
 
-  console.error('usage: stamp-mint.mjs --derive | --append --key FILE | --balances | --declare-rules stamps-v2 --meeps a,b,c --date D --key FILE | --declare-registry "handle = key" --date D --key FILE | --gift <handle> --amount N --slug S --by <founder> --date D --key FILE  [--repo PATH]');
+  console.error('usage: stamp-mint.mjs --derive | --append --key FILE | --balances | --declare-rules stamps-v2 --meeps a,b,c --date D --key FILE | --declare-rules stamps-v3 --meeps a,b,c --friendship 5:5,10:10 --date D --key FILE | --declare-registry "handle = key" --date D --key FILE | --gift <handle> --amount N --slug S --by <founder> --date D --key FILE  [--repo PATH]');
   process.exit(1);
 }
 

--- a/tools/stamp-verify.mjs
+++ b/tools/stamp-verify.mjs
@@ -30,7 +30,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  parseDeliveries, householdKeys, deriveMints, settlementDecision, meepChecker, rulesLine,
+  parseDeliveries, householdKeys, deriveMints, deriveFriendshipMints, combineDerived,
+  settlementDecision, meepChecker, rulesLine,
   parseStampLedger, sealChain, foldBalances, parseLaws, classifyEntry, walkLedger,
 } from './stamp-mint.mjs';
 
@@ -73,7 +74,12 @@ export function verifyStampLedger(repo, { pubkeyPem } = {}) {
   if (recorded[0] !== rulesLine(genesisDate))
     problems.push(`line 1: ledger must open with "${rulesLine(genesisDate)}" — found "${recorded[0]}"`);
   const households = householdKeys(repo);
-  const mints = deriveMints(deliveries, households, { laws, revisions });
+  // the full derived subsequence: correspondence mints + the stamps-v3 friendship
+  // milestone mints, in ledger order. Friendship mints ride the replay exactly
+  // like correspondence mints, so a forged one turns REPLAY red.
+  const corrMints = deriveMints(deliveries, households, { laws, revisions });
+  const friendMints = deriveFriendshipMints(deliveries, households, { laws, revisions });
+  const mints = combineDerived(deliveries, corrMints, friendMints);
   const walk = walkLedger(recorded.slice(1), mints, 1);
   for (const p of walk.problems) problems.push(p);
   if (walk.problems.length === 0 && walk.owed.length > 0)


### PR DESCRIPTION
Engine half of the town's fourth earning rule — gold plan `postmark-budding-friendship`. **Held for Wright's review; the live `rules: stamps-v3` law line is NOT sealed here (constraint 3).**

## What it does
When a **cross-household** pair of **non-meep** handles reaches a rung threshold in **both** directions (5 each way, then 10 — the ladder is pinned in the law line), counting only deliveries **on/after the stamps-v3 law date**, mint the rung's reward to **both** sides — once per pair per rung. Both mint or neither does (the deliberate divergence from mint rule 5: "no meeps allowed", Keemin).

## How it stays parity-safe
- Friendship mints join the **derived** subsequence, so `walkLedger` / `stamp-verify` replay them exactly — a forged friendship stamp turns REPLAY red like any mint.
- **Forward-only is structural:** with no `stamps-v3` law recorded, `deriveFriendshipMints` returns nothing and the engine is **inert on the current ledger**. It can merge before the law is sealed and does nothing until then.
- The v3 line **carries the meep set forward** (`lawAt` returns the latest law only) plus the rung ladder.

## Evidence
- **69/69 tests green** (60 prior + 9 new `stamp-friendship.test.mjs`): threshold, reward, the ladder, forward-only (pre-law history ignored + counts restart at the law), cross-household, non-meep, both-or-neither, once-per-rung, CRLF ledger, forged-line-fails-replay, retroactive-declaration-refused.
- **Real-ledger parity:** re-deriving the current ledger shows **0 pre-law byte-divergences** and **0 friendship mints**. (The 8 "owed" the verifier reports are pre-existing correspondence lag, present on the unmodified engine too — not friendship, not this PR.)

## The seal step (yours, with the office pen)
```
node tools/stamp-mint.mjs --declare-rules stamps-v3 \
  --meeps illuminator,jetto-of-starforge,postmaster \
  --friendship 5:5,10:10 --date <MERGE-DAY> --key <office-pen>
```
producing: `- <MERGE-DAY> · rules: stamps-v3 · meeps: illuminator,jetto-of-starforge,postmaster · friendship: 5:5,10:10 · sig: …`

Site half (pair-page achievement + daily-card fix) is a separate PR on the atelier repo. Build: jetto-of-starforge (Meep), for review.