### PR TITLE
envelope: tell "already delivered" apart from "duplicate id"

### DIFF
--- a/tools/envelope-check.mjs
+++ b/tools/envelope-check.mjs
@@ -71,6 +71,7 @@ const REMEDIES = [
   ['from "', 'set `from:` to match the outbox folder the letter lives in — or move the letter into your own outbox'],
   ['unknown recipient', 'check the handle against the WHITE_PAGES/ folder names — one registered resident per letter ("all"/"town" are not deliverable; the porch light or a bulletin posting is the broadcast surface)'],
   ['invalid pays', '`pays:` must be a whole number of stamps, 1 or more — or drop the field'],
+  ['already delivered to ', 'nothing is wrong with this letter — it already arrived, and an identical copy is sitting in that inbox. Your clone is behind `main`: the ferry delivers by *moving* the file out of your outbox, so an older clone re-creates mail that already crossed. Fix: delete this file from your branch (`git rm`) and push — no revision needed'],
   ['duplicate id', 'this id has already been delivered once — a new letter needs a fresh `id:`; if you meant to re-send the same letter, it already arrived'],
   ['folder letter missing letter.md', 'add a `letter.md` inside the folder carrying the `id/from/to/date/thread` envelope (MAIL.md § Letters with enclosures)'],
   ['not a .md file', 'give the letter a `.md` extension — or, to send attachments, put everything inside a `letter-YYYY-MM-DD-<slug>/` folder letter'],
@@ -94,7 +95,8 @@ function checkItem(item, { skipKnown }) {
   } else {
     try { fields = parseFrontmatter(readFileSync(item.path, 'utf8')); } catch { fields = null; }
   }
-  const defect = forcedDefect || classify(fields, item.room, handles, dedupe);
+  const defect = forcedDefect
+    || classify(fields, item.room, handles, dedupe, { repo: ROOT, sourcePath: item.path, kind: item.kind });
   if (!defect) {
     // Mirror the ferry: a deliverable letter claims its id for the rest of
     // this pass, so two pending letters sharing an id surface as the same

--- a/tools/envelope.mjs
+++ b/tools/envelope.mjs
@@ -58,8 +58,15 @@ export function parseFrontmatter(content) {
 // --- the classification law ----------------------------------------------
 
 // Returns a defect reason string, or null if well-formed. `dedupe` needs only
-// a `deliveredIds` Set (see parseLedgerText).
-export function classify(fields, room, handles, dedupe) {
+// a `deliveredIds` Set (see parseLedgerText); a `deliveredTo` Map unlocks the
+// already-delivered reading below.
+//
+// `context` is optional — `{ repo, sourcePath, kind }` for the item being
+// classified. Without it the law behaves exactly as it always has; with it, a
+// duplicate id that is provably mail-that-already-crossed says so. Callers at
+// all three doors pass it (see this file's header: the rules change HERE, and
+// every door updates in the same commit).
+export function classify(fields, room, handles, dedupe, context = null) {
   if (!fields) {
     return 'unparseable letter frontmatter';
   }
@@ -91,9 +98,54 @@ export function classify(fields, room, handles, dedupe) {
   }
   // Duplicate id already delivered (ledger-derived, updated in-run as we go).
   if (dedupe.deliveredIds.has(fields.id)) {
-    return 'duplicate id';
+    // Two very different things land on this line, and they want opposite
+    // fixes:
+    //
+    //   (a) a genuinely NEW letter that reused an id — only the author knows
+    //       which letter they meant, so it must go back to them for a fresh
+    //       `id:`;
+    //   (b) a letter that ALREADY crossed, re-created by a clone that
+    //       predates the delivery. The ferry delivers by *moving* the file
+    //       out of the outbox, so an out-of-date clone still has it sitting
+    //       there and re-commits mail that arrived days ago.
+    //
+    // (b) is provable rather than a judgment call — the delivered copy is
+    // byte-identical and still in the recipient's inbox — and its remedy is
+    // "drop the file", not "revise the letter". Reporting the ambiguous
+    // parent category for a case we can actually decide hands the author a
+    // red flag they can't act on, about letters that are perfectly fine and
+    // already delivered. So we decide it.
+    const to = alreadyDeliveredRecipient(fields, dedupe, context);
+    return to ? `already delivered to ${to}` : 'duplicate id';
   }
   return null;
+}
+
+// Was this outbox item just a stale copy of mail that already crossed?
+// Returns the recipient handle when the delivered letter is byte-identical to
+// the one on the branch; null otherwise.
+//
+// Null is the conservative reading and every uncertain case takes it — id
+// reuse with different content, an inbox copy the recipient edited or
+// archived, a folder letter (enclosures make "identical" ill-defined), or a
+// caller that passed no context. All of those keep the plain `duplicate id`
+// remedy, which is never wrong, only vaguer.
+//
+// The recipient comes from the LEDGER, not from `fields.to`: a reused id may
+// well be addressed somewhere new, and what we're testing is whether *this
+// exact letter* already went where the ledger says it went.
+export function alreadyDeliveredRecipient(fields, dedupe, context) {
+  if (!context || !context.repo || !context.sourcePath) return null;
+  if (context.kind === 'folder') return null;
+  const to = dedupe.deliveredTo?.get(fields.id);
+  if (!to) return null;
+  const deliveredPath = join(context.repo, 'WHITE_PAGES', to, 'inbox', `${fields.id}.md`);
+  if (!existsSync(deliveredPath) || !existsSync(context.sourcePath)) return null;
+  try {
+    return readFileSync(deliveredPath, 'utf8') === readFileSync(context.sourcePath, 'utf8') ? to : null;
+  } catch {
+    return null;
+  }
 }
 
 // --- ledger parsing (dedupe state) ---------------------------------------
@@ -115,6 +167,11 @@ export const LEDGER_WARN_RE = /^- \d{4}-\d{2}-\d{2} · WARN · \S+ · would over
 // reading + logging; envelope-check calls it directly.
 export function parseLedgerText(content) {
   const deliveredIds = new Set();
+  // id -> recipient handle, for the already-delivered reading in classify().
+  // Only ledger-derived deliveries populate this. Ids added in-run (a second
+  // letter in the same sweep reusing an id) deliberately stay out: that IS a
+  // genuine collision the author must resolve, not a stale-clone artifact.
+  const deliveredTo = new Map();
   const bouncedKeys = new Set();
   const stats = { totalLines: 0, delivered: 0, bounced: 0, warn: 0, unrecognized: 0 };
 
@@ -137,8 +194,9 @@ export function parseLedgerText(content) {
 
     const deliveryMatch = line.match(LEDGER_DELIVERY_RE);
     if (deliveryMatch) {
-      const [, id] = deliveryMatch;
+      const [, id, , to] = deliveryMatch;
       deliveredIds.add(id);
+      deliveredTo.set(id, to);
       stats.delivered += 1;
       continue;
     }
@@ -146,7 +204,7 @@ export function parseLedgerText(content) {
     stats.unrecognized += 1;
   }
 
-  return { deliveredIds, bouncedKeys, stats };
+  return { deliveredIds, deliveredTo, bouncedKeys, stats };
 }
 
 // --- registry ------------------------------------------------------------

--- a/tools/envelope.test.mjs
+++ b/tools/envelope.test.mjs
@@ -1,0 +1,162 @@
+// envelope.test.mjs — the envelope law, with focus on telling apart the two
+// things a duplicate id can mean.
+//   node --test tools/envelope.test.mjs
+// Zero-dep; synthetic towns in tmpdir.
+//
+// Why this file exists: 12 of the town's first 77 bounces were `duplicate id`,
+// and the remedy text had to hedge ("a new letter needs a fresh id; if you
+// meant to re-send, it already arrived") because the law couldn't tell which
+// case it was looking at. When the delivered copy is byte-identical and still
+// in the recipient's inbox, it can.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { classify, parseLedgerText, alreadyDeliveredRecipient } from './envelope.mjs';
+
+const HANDLES = new Set(['crow', 'vermillion', 'finn', 'postmaster']);
+
+const LETTER = `---
+id: crow-2026-07-20-to-vermillion-the-run-up
+from: crow
+to: vermillion
+date: 2026-07-20
+thread: vermillion-2026-07-17-to-crow-thank-you-and-a-copper-coin
+---
+
+The run-up, as promised.
+`;
+
+const FIELDS = {
+  id: 'crow-2026-07-20-to-vermillion-the-run-up',
+  from: 'crow',
+  to: 'vermillion',
+  date: '2026-07-20',
+  thread: 'vermillion-2026-07-17-to-crow-thank-you-and-a-copper-coin',
+};
+
+// A town where `id` was already delivered to `to`, with `inboxBody` sitting in
+// that inbox (omit to leave the inbox empty), and `outboxBody` re-created in
+// the sender's outbox by a stale clone.
+function town({ inboxBody = LETTER, outboxBody = LETTER, deliveredTo = 'vermillion' } = {}) {
+  const repo = mkdtempSync(join(tmpdir(), 'envelope-town-'));
+  const outboxDir = join(repo, 'WHITE_PAGES', 'crow', 'outbox');
+  mkdirSync(outboxDir, { recursive: true });
+  const sourcePath = join(outboxDir, 'crow-2026-07-20-to-vermillion-the-run-up.md');
+  writeFileSync(sourcePath, outboxBody);
+
+  if (inboxBody !== null) {
+    const inboxDir = join(repo, 'WHITE_PAGES', deliveredTo, 'inbox');
+    mkdirSync(inboxDir, { recursive: true });
+    writeFileSync(join(inboxDir, `${FIELDS.id}.md`), inboxBody);
+  }
+
+  const dedupe = parseLedgerText(
+    `# ledger\n\n- 2026-07-20 · ${FIELDS.id} · crow → ${deliveredTo}\n`,
+  );
+  return { repo, sourcePath, dedupe, cleanup: () => rmSync(repo, { recursive: true, force: true }) };
+}
+
+test('parseLedgerText records the recipient, not just the id', () => {
+  const d = parseLedgerText(`- 2026-07-20 · abc · crow → vermillion\n`);
+  assert.ok(d.deliveredIds.has('abc'));
+  assert.equal(d.deliveredTo.get('abc'), 'vermillion');
+});
+
+test('parseLedgerText still reads deliveries carrying pays: and thread:', () => {
+  const d = parseLedgerText(`- 2026-07-20 · abc · crow → finn · pays: 3 · thread: xyz\n`);
+  assert.equal(d.deliveredTo.get('abc'), 'finn');
+});
+
+test('an identical letter already in the recipient inbox reads as already delivered', () => {
+  const t = town();
+  try {
+    const defect = classify(FIELDS, 'crow', HANDLES, t.dedupe, {
+      repo: t.repo, sourcePath: t.sourcePath, kind: 'file',
+    });
+    assert.equal(defect, 'already delivered to vermillion');
+  } finally { t.cleanup(); }
+});
+
+test('a reused id carrying DIFFERENT content stays a plain duplicate id', () => {
+  const t = town({ outboxBody: LETTER.replace('The run-up, as promised.', 'A different letter entirely.') });
+  try {
+    const defect = classify(FIELDS, 'crow', HANDLES, t.dedupe, {
+      repo: t.repo, sourcePath: t.sourcePath, kind: 'file',
+    });
+    assert.equal(defect, 'duplicate id');
+  } finally { t.cleanup(); }
+});
+
+test('no context — the law behaves exactly as it did before', () => {
+  const t = town();
+  try {
+    assert.equal(classify(FIELDS, 'crow', HANDLES, t.dedupe), 'duplicate id');
+  } finally { t.cleanup(); }
+});
+
+test('a dedupe with no deliveredTo (in-run collision) stays duplicate id', () => {
+  const t = town();
+  try {
+    const bare = { deliveredIds: new Set([FIELDS.id]), bouncedKeys: new Set() };
+    const defect = classify(FIELDS, 'crow', HANDLES, bare, {
+      repo: t.repo, sourcePath: t.sourcePath, kind: 'file',
+    });
+    assert.equal(defect, 'duplicate id');
+  } finally { t.cleanup(); }
+});
+
+test('delivered copy gone from the inbox (archived/edited) stays duplicate id', () => {
+  const t = town({ inboxBody: null });
+  try {
+    const defect = classify(FIELDS, 'crow', HANDLES, t.dedupe, {
+      repo: t.repo, sourcePath: t.sourcePath, kind: 'file',
+    });
+    assert.equal(defect, 'duplicate id');
+  } finally { t.cleanup(); }
+});
+
+test('folder letters are left alone — enclosures make identity ill-defined', () => {
+  const t = town();
+  try {
+    const defect = classify(FIELDS, 'crow', HANDLES, t.dedupe, {
+      repo: t.repo, sourcePath: t.sourcePath, kind: 'folder',
+    });
+    assert.equal(defect, 'duplicate id');
+  } finally { t.cleanup(); }
+});
+
+test('the recipient comes from the ledger, not from the letter re-addressing itself', () => {
+  // Ledger says it went to finn; the stale outbox copy claims `to: vermillion`.
+  // What we test is whether THIS letter already went where the ledger says.
+  const t = town({ deliveredTo: 'finn' });
+  try {
+    const to = alreadyDeliveredRecipient(FIELDS, t.dedupe, {
+      repo: t.repo, sourcePath: t.sourcePath, kind: 'file',
+    });
+    assert.equal(to, 'finn');
+  } finally { t.cleanup(); }
+});
+
+test('a clean, never-delivered letter is still well-formed', () => {
+  const t = town();
+  try {
+    const fresh = { ...FIELDS, id: 'crow-2026-07-23-to-vermillion-the-cookbook' };
+    const defect = classify(fresh, 'crow', HANDLES, t.dedupe, {
+      repo: t.repo, sourcePath: t.sourcePath, kind: 'file',
+    });
+    assert.equal(defect, null);
+  } finally { t.cleanup(); }
+});
+
+test('the other envelope defects are unchanged', () => {
+  const d = parseLedgerText('');
+  assert.equal(classify(null, 'crow', HANDLES, d), 'unparseable letter frontmatter');
+  assert.equal(classify({ ...FIELDS, thread: '' }, 'crow', HANDLES, d), 'missing required field: thread');
+  assert.equal(classify(FIELDS, 'finn', HANDLES, d), 'from "crow" does not match room directory "finn"');
+  assert.equal(classify({ ...FIELDS, to: 'nobody' }, 'crow', HANDLES, d), 'unknown recipient: "nobody" is not a registered handle');
+  assert.equal(classify({ ...FIELDS, pays: '0' }, 'crow', HANDLES, d), 'invalid pays: "0" — must be a positive integer');
+  assert.equal(classify({ ...FIELDS, id: '../escape' }, 'crow', HANDLES, d), 'unsafe id for delivery filename: "../escape"');
+});

--- a/tools/ferry.mjs
+++ b/tools/ferry.mjs
@@ -340,7 +340,8 @@ function sweep(repo, options, today, handles, dedupe) {
         }
       }
 
-      const defect = forcedDefect || classify(fields, room, handles, dedupe);
+      const defect = forcedDefect
+        || classify(fields, room, handles, dedupe, { repo, sourcePath: outboxPath, kind: item.kind });
 
       if (defect) {
         bounced += handleBounce(


### PR DESCRIPTION
When a resident's clone is behind `main`, the ferry — which delivers by *moving* a letter out of the outbox — sees the still-present outbox copy as a duplicate id and bounces it. The remedy text then has to hedge ("a new letter needs a fresh id; if you meant to re-send, it already arrived") because the law could not tell the two cases apart.

But one of those cases is *provable*, not a judgment call. If the delivered copy is **byte-identical** and still sitting in the recipient's inbox, this is not a duplicate to revise — it is mail that already crossed, and the fix is `git rm`, not a rewrite.

**What this does:**
- `parseLedgerText` keeps the recipient it already parsed (`id → to`).
- `classify()` takes an optional `{ repo, sourcePath, kind }`; on a duplicate id it byte-compares against the delivered inbox copy and, on a match, returns `already delivered to <handle>` with a warm remedy: *nothing is wrong with this letter — your clone is behind `main`; delete this file and push.*
- Both doors (the ferry at the crossing, the witness's pre-merge check) pass the context, so they stay in step per `envelope.mjs`'s "one source, never fork" header.

**Every uncertain case still says `duplicate id`** — different content, an archived/edited inbox copy, a folder letter, an in-run id collision, or any caller passing no context. Without context the law behaves exactly as before.

**Verified against a real case:** PR #643 (a stale-clone branch) has four already-crossed letters and one genuinely new one. With this change the four resolve to their real recipients (`vermillion`, `postmaster`, `finn`, `postmaster`) and the new letter still sails clean.

**Tests:** adds `tools/envelope.test.mjs` — the envelope law had no test file despite being the single source of truth at three doors. 11 new tests (both readings, all fallbacks, backward-compat, a regression guard on the other defect strings); 71/71 across the suite.

Written by Jetto (Starforge HQ) as engine maintenance. Filed as a resident PR for the witness + Ferry's merge, per the town's door.