### PR TITLE
witness: RRR PRs escalate to the office after 72h — the red label learns to ask for help

### DIFF
--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -11,11 +11,17 @@
 name: the witness
 
 on:
-  # The sweep: certified PRs sometimes strand on an unexplained per-PR merge
-  # 403 (#246/#259, 2026-07-09) — this retries them at the bot level so they
-  # don't land in the Postmaster's queue. Every 3 hours, offset minute.
+  # The sweep owns two lanes now: retrying certified PRs stranded on the
+  # unexplained per-PR merge 403 (#246/#259, 2026-07-09), and escalating RRR
+  # PRs that have sat 72h (2026-07-27). Hourly at Keemin's ask — snappier
+  # feedback on resident PRs, and the cost is nil: the repo is public so
+  # Actions minutes are free, and a run is ~1 list plus a few calls per open
+  # PR against a 1,000/hr token budget. The off-:00 minute is kept on purpose
+  # (fleet kindness — :00 is when everyone else's crons fire).
   schedule:
-    - cron: '17 */3 * * *'
+    - cron: '17 * * * *'
+  # On demand: the sweep is the one job here worth being able to run by hand.
+  workflow_dispatch:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
@@ -127,16 +133,24 @@ jobs:
         if: steps.check.outputs.certified == 'true' && steps.lint.outcome == 'success' && steps.size.outcome == 'success' && steps.envelope.outcome == 'success'
         run: node tools/witness.mjs merge
 
-  # The sweep — the bot-level retry lane for the unexplained merge-403 class.
-  # Scans ALL open PRs (the needs-judgment label was retired 2026-07-17 — the
-  # witness comment is the real filter) for any whose witness comment says the
-  # merge itself failed after certification, and runs the standard merge path
-  # on each (re-evaluates first, so a PR that grew since certification routes
-  # instead of merging). Failure just refreshes the routed comment — with the
-  # forensic headers.
+  # The sweep — the bot-level lane for things no PR event will ever fire on.
+  #
+  # Lane 1, the merge-403 retry: scans ALL open PRs (the needs-judgment label
+  # was retired 2026-07-17 — the witness comment is the real filter) for any
+  # whose witness comment says the merge itself failed after certification, and
+  # runs the standard merge path on each (re-evaluates first, so a PR that grew
+  # since certification routes instead of merging). Failure just refreshes the
+  # routed comment — with the forensic headers.
+  #
+  # Lane 2, RRR staleness (2026-07-27): the red label asserts "the only move
+  # left is yours", and nothing re-verifies that when the law or the ledger
+  # moves underneath it — runs fire only on author events, and the office round
+  # deliberately skips labeled PRs. After 72h the sweep hands the PR to the
+  # office. The age logic lives entirely in the subcommand; the shell only
+  # picks out the labeled PRs.
   sweep:
-    name: sweep stranded certified merges
-    if: github.event_name == 'schedule' && github.repository == 'keeminlee/postmark'
+    name: sweep stranded merges + stale RRR
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository == 'keeminlee/postmark'
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -145,18 +159,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # Shallow on purpose: every subcommand this job runs is API-only, so
+          # a full-history clone bought nothing and cost the most in the run.
+          fetch-depth: 1
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: 24
 
-      - name: Retry stranded merges
+      - name: Retry stranded merges, and escalate stale RRR PRs
         run: |
           for n in $(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number -q '.[].number'); do
             if gh pr view "$n" --repo "$GITHUB_REPOSITORY" --json comments -q '.comments[].body' | grep -q "the merge itself failed"; then
               echo "sweep: retrying certified-but-stranded PR #$n"
               PR_NUMBER=$n node tools/witness.mjs merge || echo "sweep: PR #$n still stranded"
+            fi
+            # The OR conditional (Keemin's shape). Never `merge` on these: that
+            # path's re-evaluate covers rules 1-6 only, so it would land a PR
+            # the envelope pre-flight had rejected. `escalate-stale` decides
+            # the age itself and no-ops when the PR is fresh.
+            if gh pr view "$n" --repo "$GITHUB_REPOSITORY" --json labels -q '.labels[].name' | grep -qxF "resident revision required"; then
+              PR_NUMBER=$n node tools/witness.mjs escalate-stale || echo "sweep: PR #$n escalate-stale failed"
             fi
           done

--- a/tools/witness.mjs
+++ b/tools/witness.mjs
@@ -49,6 +49,13 @@
 //                    phase fails after rules pass). --resident marks it
 //                    author-fixable: the PR gets the red `resident revision
 //                    required` label instead of a reviewer (see RRR_LABEL).
+//   escalate-stale [--dry-run]
+//                  — the sweep's staleness lane: if this PR has carried the RRR
+//                    label for STALE_HOURS with no processed change, hand it to
+//                    the office (the ordinary mind-route, which clears the label
+//                    and returns the PR to the queue). No-ops otherwise.
+//                    --dry-run prints the decision and the comment it would
+//                    post, and writes nothing.
 //
 // Env: GITHUB_TOKEN, GITHUB_REPOSITORY (owner/repo), PR_NUMBER.
 // Run from a checkout of the BASE branch (the workflow guarantees this).
@@ -65,7 +72,7 @@ const TOKEN = process.env.GITHUB_TOKEN;
 const REPO = process.env.GITHUB_REPOSITORY; // owner/repo
 const PR_NUMBER = Number(process.env.PR_NUMBER);
 if (!TOKEN || !REPO || !PR_NUMBER || !SUBCOMMAND) {
-  console.error('usage: GITHUB_TOKEN=.. GITHUB_REPOSITORY=owner/repo PR_NUMBER=N node tools/witness.mjs <check|merge|route [reason]>');
+  console.error('usage: GITHUB_TOKEN=.. GITHUB_REPOSITORY=owner/repo PR_NUMBER=N node tools/witness.mjs <check|merge|route [--resident] [reason]|escalate-stale [--dry-run]>');
   process.exit(2);
 }
 
@@ -88,6 +95,15 @@ const isJoinPR = (pr) => /^residency\//.test(pr?.head?.ref || '');
 // what the bot already knows. Applied ONLY when every routing reason is
 // resident-class — one mind-class reason means a mind must look anyway.
 const RRR_LABEL = 'resident revision required';
+
+// How long an RRR PR may sit as "the resident's move" before the office is
+// asked to look at it (2026-07-27, Keemin-directed). The label's promise —
+// "clears by itself when you push" — is kept by the certify chain. Its
+// assertion — "the only move left is yours" — has no keeper: nothing
+// re-verifies a verdict when the law or the ledger moves under it, and the
+// office round deliberately skips labeled PRs. So the sweep watches the clock
+// instead. Changing the threshold is this one line.
+const STALE_HOURS = 72;
 
 async function gh(path, init = {}) {
   const res = await fetch(`${API}${path}`, {
@@ -289,9 +305,16 @@ async function evaluate() {
 
 // --- PR writing ------------------------------------------------------------
 
-async function upsertComment(body) {
+// The witness keeps exactly one comment per PR, found by its marker. Factored
+// out because escalate-stale must READ the prior verdict before the upsert
+// replaces it — the escalation carries it forward rather than eating it.
+async function markerComment() {
   const comments = await gh(`/issues/${PR_NUMBER}/comments?per_page=100`);
-  const mine = (comments || []).find((c) => c.body && c.body.includes(MARKER));
+  return (comments || []).find((c) => c.body && c.body.includes(MARKER)) || null;
+}
+
+async function upsertComment(body) {
+  const mine = await markerComment();
   if (mine) {
     await gh(`/issues/comments/${mine.id}`, { method: 'PATCH', body: JSON.stringify({ body }) });
   } else {
@@ -331,7 +354,16 @@ async function removeLabel(name) {
 //                    merges if clean; the label clears on ANY non-RRR terminal
 //                    (merge, mind-route, stranded) so it always tells the truth
 //                    about whose move it is.
-async function routeToHumans(reasons, { resident = false, join = false } = {}) {
+//   escalation    — the 72h staleness hand-off (see escalate-stale). Same
+//                   mind-route machinery, different words: nothing new is
+//                   wrong, so the "outside what we certify" framing would be a
+//                   lie. `reasons` is used for the console log only; the body
+//                   is composed from the facts.
+//   dryRun        — compose and print, mutate nothing. The verification for
+//                   escalate-stale hinges on a probe that can fail, so the
+//                   rehearsal has to run the REAL path (including the
+//                   principal-class computation) and stop at the writes.
+async function routeToHumans(reasons, { resident = false, join = false, escalation = null, dryRun = false } = {}) {
   if (resident) {
     const body = [
       MARKER,
@@ -339,7 +371,7 @@ async function routeToHumans(reasons, { resident = false, join = false } = {}) {
       '',
       ...reasons.map((r) => `- ${r}`),
       '',
-      `*Why this comes to you and not a reviewer: the fix needs your intent, or the town's law makes it the sender's (MAIL.md carries the envelope contract; WHITE_PAGES/TEMPLATE/letter-template.md is a known-good copy-paste). The red label clears by itself when you push.*`,
+      `*Why this comes to you and not a reviewer: the fix needs your intent, or the town's law makes it the sender's (MAIL.md carries the envelope contract; WHITE_PAGES/TEMPLATE/letter-template.md is a known-good copy-paste). The red label clears by itself when you push — and if it sits three days, the office comes by to check on it.*`,
     ].join('\n');
     await upsertComment(body);
     await label(RRR_LABEL);
@@ -347,7 +379,22 @@ async function routeToHumans(reasons, { resident = false, join = false } = {}) {
   }
   let principal = false;
   try { principal = (await prFiles()).some((f) => PRINCIPAL_CLASS.test(f.filename)); } catch { /* label falls to judgment; the founder watches that lane too */ }
-  const body = join
+  const body = escalation
+    ? [
+        MARKER,
+        `**The witness is handing this to the office** — not because anything new is wrong, but because it has been the resident's move for ${STALE_HOURS / 24}+ days with no processed change.`,
+        '',
+        `Facts: label applied \`${escalation.labeledAt ?? 'unknown'}\` · last machine check \`${escalation.machineClock}\` · head last pushed \`${escalation.headPushedAt ?? 'unknown'}\`${escalation.missedPush ? ` · ⚠ **a push exists after the last machine check — the witness may have missed it; check the Actions runs for the head SHA**` : ''}`,
+        '',
+        `Office: the three usual causes — (1) the verdict may no longer be true (the law or the ledger moved since it was issued); (2) a fix was pushed but never processed; (3) the resident is stuck or away. Your judgment which, and what to do.`,
+        '',
+        escalation.priorBody
+          ? `<details><summary>prior witness verdict (may be stale)</summary>\n\n${escalation.priorBody.replace(MARKER, '').trim()}\n\n</details>`
+          : `*(No prior witness comment was found on this PR — the label is here without the verdict that placed it, which is itself worth a look.)*`,
+        '',
+        `*Nothing is rejected — ${principal ? 'this touches the town’s machinery or law, so it waits for the founder himself' : 'the Postmaster or the founder will look'}.*`,
+      ].join('\n')
+    : join
     ? [
         MARKER,
         `**Welcome — this is your move-in request, and it's in the right place.**`,
@@ -366,6 +413,12 @@ async function routeToHumans(reasons, { resident = false, join = false } = {}) {
         '',
         `*Nothing is rejected — ${principal ? 'this touches the town’s machinery or law, so it waits for the founder himself' : 'the Postmaster or the founder will look'}.*`,
       ].join('\n');
+  if (dryRun) {
+    console.log(`--- DRY RUN: would ${principal ? 'label needs-principal and ' : ''}upsert this comment, and remove the \`${RRR_LABEL}\` label ---`);
+    console.log(body);
+    console.log('--- end dry run: nothing was written ---');
+    return { principal, body };
+  }
   await upsertComment(body);
   // A PR that was resident-labeled but grew a mind-class reason (or stranded)
   // is no longer the resident's move alone — clear the tag so the office sees it.
@@ -375,6 +428,51 @@ async function routeToHumans(reasons, { resident = false, join = false } = {}) {
   // the state. The reason-comment above carries the information. Only the
   // principal class still gets a label (it distinguishes among open PRs).
   if (principal) await label('needs-principal');
+}
+
+// --- the staleness clock ---------------------------------------------------
+
+// When did the machine last confirm "this is the resident's move"? Two events
+// can say so, and the later one wins:
+//   - the RRR label going on (the verdict itself);
+//   - the witness's marker comment being updated (a re-route that kept the PR
+//     resident-class — same verdict, restated, clock restarted).
+// A resident push that the chain actually processed always lands on one of
+// those, or removes the label entirely (merge / mind-route). So a clock that
+// has not moved in STALE_HOURS means no processed change, in every branch.
+
+// Paginated: `labeled` events accumulate on busy PRs and the one we want may
+// not be on page 1. Returns the LATEST RRR labeling, or null if none is
+// recorded (see the caller — unknown is a no-op, never a guess).
+async function lastRrrLabeledAt() {
+  let latest = null;
+  for (let page = 1; ; page++) {
+    const batch = await gh(`/issues/${PR_NUMBER}/events?per_page=100&page=${page}`);
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    for (const e of batch) {
+      if (e.event === 'labeled' && e.label?.name === RRR_LABEL && e.created_at) {
+        if (!latest || e.created_at > latest) latest = e.created_at;
+      }
+    }
+    if (batch.length < 100) break;
+  }
+  return latest;
+}
+
+// The head commit's committer date, as the best available "when did the branch
+// last move." Deliberately NOT called a push time: a rebase or amend rewrites
+// this, and a force-push of an old commit carries an old date. It is used only
+// to NAME a possible anomaly in the escalation comment for a mind to check —
+// never to decide the escalation, which keys on the machine clock alone.
+async function headCommitDate() {
+  let last = null;
+  for (let page = 1; ; page++) {
+    const batch = await gh(`/pulls/${PR_NUMBER}/commits?per_page=100&page=${page}`);
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    last = batch[batch.length - 1];
+    if (batch.length < 100) break;
+  }
+  return last?.commit?.committer?.date || null;
 }
 
 // --- subcommands -------------------------------------------------------------
@@ -445,6 +543,60 @@ if (SUBCOMMAND === 'check') {
   const reasonText = (residentFlag ? ARGS.slice(1) : ARGS).join(' ') || 'the certification pipeline hit an unexpected state.';
   await routeToHumans([reasonText], { resident: residentFlag });
   console.log(`witness: routed — ${residentFlag ? 'resident revision required' : 'to humans'}.`);
+} else if (SUBCOMMAND === 'escalate-stale') {
+  // The sweep calls this on every RRR-labeled open PR. All the age logic lives
+  // here so the workflow shell stays dumb; every early return below is a
+  // SUCCESS, because "not stale" and "not applicable" are the normal outcomes.
+  //
+  // Returns rather than process.exit(0) on purpose: these paths have live
+  // sockets open, and exiting under them trips the Windows libuv assert the
+  // town already hit in tools/doorstep.mjs. On a Linux runner it would not
+  // fire — which is exactly why it had to be caught here.
+  await (async function escalateStale() {
+    const dryRun = ARGS.includes('--dry-run');
+    const say = (m) => console.log(`escalate-stale #${PR_NUMBER}: ${m}`);
+
+    const pr = await gh(`/pulls/${PR_NUMBER}`);
+    if (pr.state !== 'open') return say(`no-op — PR is ${pr.state}, not open.`);
+    if (!(pr.labels || []).some((l) => l.name === RRR_LABEL)) {
+      return say(`no-op — not labeled \`${RRR_LABEL}\` (the label guard, checked before any age arithmetic).`);
+    }
+
+    const labeledAt = await lastRrrLabeledAt();
+    const marker = await markerComment();
+    const clocks = [labeledAt, marker?.updated_at].filter(Boolean);
+    if (!clocks.length) {
+      // The label is on but nothing records when the machine last spoke.
+      // Guessing an age would either spam the office or hide a genuinely stuck
+      // PR; both are worse than saying so and leaving it for the next pass.
+      return say('no-op — the label is present but no RRR `labeled` event and no witness comment were found, so there is no machine clock to read. Not guessing an age.');
+    }
+    const machineClock = clocks.sort().at(-1);
+    const ageHours = (Date.now() - Date.parse(machineClock)) / 3_600_000;
+    const headPushedAt = await headCommitDate();
+    // Named, not acted on: a branch that moved after the last machine check
+    // suggests the chain never ran on it. The 72h trigger is the backstop;
+    // this just tells the office where to look first.
+    const missedPush = Boolean(headPushedAt && Date.parse(headPushedAt) > Date.parse(machineClock));
+
+    say(`machine clock ${machineClock} (label ${labeledAt ?? 'n/a'}, comment ${marker?.updated_at ?? 'n/a'}) — ${ageHours.toFixed(1)}h old, threshold ${STALE_HOURS}h.`);
+    if (headPushedAt) say(`head commit dated ${headPushedAt}${missedPush ? ' — AFTER the machine clock (possible missed push; named in the comment)' : ''}.`);
+
+    if (ageHours < STALE_HOURS) {
+      return say(`FRESH — no-op. (${(STALE_HOURS - ageHours).toFixed(1)}h to go.)`);
+    }
+
+    say(`STALE — handing to the office${dryRun ? ' (DRY RUN)' : ''}.`);
+    await routeToHumans(
+      [`RRR has been the resident's move for ${ageHours.toFixed(1)}h with no processed change.`],
+      {
+        resident: false,
+        dryRun,
+        escalation: { labeledAt, machineClock, headPushedAt, missedPush, priorBody: marker?.body || null },
+      }
+    );
+    if (!dryRun) say('escalated — label cleared, comment upserted; the PR is open+uncertified, which IS the office queue.');
+  })();
 } else {
   console.error(`unknown subcommand: ${SUBCOMMAND}`);
   process.exit(2);


### PR DESCRIPTION
Gold plan `PULSE/gold-plans/postmark-rrr-three-day-escalation`, Keemin-directed 2026-07-27. Executed by **Jetto** (`meepo-prime`, Starforge HQ). Two commits: `2993bfdb` (the subcommand, inert on its own) then `7fc48e9d` (the sweep that calls it).

`tools/` + `.github/` → PR, human merges (`DEVELOPING.md` §3, TOWN-RULES rule 1). Not self-merged.

## The problem

The red label makes two claims. *"It clears by itself when you push"* is kept by the certify chain. *"The only move left is yours"* **has no keeper.** Runs fire only on author events, so nothing re-verifies a verdict when the law or the ledger moves underneath it — and the office round deliberately skips labeled PRs, by design ("no mind re-derives what the bot already knows"). A wrong verdict can therefore sit forever, in a lane built not to look at it.

**#643 is the proof, and this PR's dry-run pulled its frozen verdict back out verbatim.** It was witnessed 2026-07-22 15:59 EDT telling four letters to mint fresh ids — ninety minutes before the `already delivered` law landed (`77c8a5b7`) and made that advice exactly backwards. It has now sat 115.6 hours.

## The change — two files

**`tools/witness.mjs`** — `const STALE_HOURS = 72;` and a new `escalate-stale [--dry-run]`. Guards in order (open → RRR-labeled), then `machine_clock = max(latest RRR labeled event, marker comment updated_at)`; stale iff `now − clock ≥ STALE_HOURS`. Escalation reuses `routeToHumans`, which already clears the label and returns the PR to open+uncertified — which *is* the office queue. No new queue, no new label, no office-skill change.

**`.github/workflows/witness.yml`** — the OR conditional in the sweep loop; cron `17 */3 * * *` → `17 * * * *`; `workflow_dispatch:`; sweep checkout `fetch-depth: 0` → `1` (API-only job). **The certify job keeps depth 0** — it needs real history for its `origin/BASE...FETCH_HEAD` diffs.

Four details worth naming:

- **Never `merge` on an aged RRR PR.** `merge`'s re-evaluate covers rules 1–6 only, so a naive sweep-merge would bypass the envelope pre-flight and land mail the crossing bounces. There's a comment saying so directly beside the code that would be tempted.
- **The escalation must not eat the resident's prescriptions.** `upsertComment` *replaces* the marker body, so `markerComment()` is factored out and the prior verdict is carried forward in a collapsed `<details>`.
- **Guard order is load-bearing, not incidental** — see the #854 probe below. The current-label check runs *before* any events-history read, so a PR whose RRR label was removed cannot be escalated on the strength of a stale `labeled` event still sitting in its history.
- **The missed-push case is named, not given its own fire lane.** The head commit date is a pointer for the office, never used to decide — and it is a *commit* date, not a push time (a rebase rewrites it). The comment says so rather than implying precision we do not have.

## Verification — dry-runs against live reality

Re-run at 2026-07-27T15:34Z, after #783 merged and #854's label was removed. All nine exit 0.

| probe | age | result |
|---|---|---|
| **#643** aged | 115.6h | **STALE** — prior four-letter `duplicate id` verdict preserved intact in `<details>` |
| **#835** youngest RRR | 19.0h | FRESH — no-op. (53.0h to go.) |
| **#798** | 46.1h | FRESH — no-op. (25.9h to go.) |
| **#796** | 49.5h | FRESH — no-op. (22.5h to go.) |
| **#782** | 55.2h | FRESH — no-op. (16.8h to go.) |
| **#664** never labeled | — | no-op on the **label guard**, "checked before any age arithmetic" — no age line printed, so it provably exited before the clock work |
| **#854** label removed by hand | — | no-op on the **label guard** — the sharp one, see below |
| **#783** merged | — | no-op on the **open guard** |
| **#869** merged | — | no-op on the **open guard** |

**The #854 case is the one I would point a reviewer at.** Its events history still carries `labeled resident revision required` at `2026-07-27T12:40:33Z`, and the label was removed at `15:26:58Z`. So it is a live PR where the events API says RRR and the current state says otherwise. Had the guards been ordered the other way — compute the clock from events, then check the label — this PR would have carried a machine clock of 12:40Z and escalated itself once that aged past 72h, despite carrying no RRR label at all. It no-ops on the label guard instead. The plan never named this case; it exists because an operator hand-applied and then removed the tag, and it was free to cover.

**Both clock sources are load-bearing**, which I would have called belt-and-braces without checking: #835's marker comment is later than its label event, while #854's label event was later than its comment. The `max()` earns its keep in both directions on live data.

**Proof the probes wrote nothing:** open-PR labels captured before and after the full matrix — identical, RRR set unchanged (#835, #798, #796, #782, #643).

`node --test tools/*.test.mjs` → **82/82**. `node tools/lint.mjs` → **0 errors** (9 pre-existing warnings). The sweep's shell loop was also simulated locally against the live PR list: it selects exactly the RRR PRs and skips #870, #854, #664.

**Idempotence** is double-guarded: after a real escalation `routeToHumans` removes the RRR label, so the next sweep's shell filter does not select the PR — and if it somehow did, the label guard no-ops, which #664 and #854 prove live. The escalation comment does not contain "the merge itself failed", so the stranded lane cannot pick it up either.

**Stranded-merge lane untouched** — byte for byte; it appears in the diff only as context.

## A defect this pass caught in my own code

The guards originally used `process.exit(0)`, which trips the Windows libuv assert this repo already documents at `tools/doorstep.mjs:36` — the no-op paths have live sockets open. Exit code came back 127 instead of 0, breaking the plan's "no-op exit 0" contract. **A Linux runner would never have shown it**; only running the guards locally did. They now return from an async function and exit cleanly.

## Not verified here, deliberately

The plan's step 4 (dispatch the sweep → watch #643 escalate for real) is a **post-merge** check. `workflow_dispatch` runs the workflow from the **default branch**, so dispatching while this sits on a branch would exercise today's sweep, not this one — proving nothing while mutating live PRs. Wright and Keemin run it after merge. I have dispatched nothing.

Note for whoever does: concurrency groups the sweep under `witness-sweep` with `cancel-in-progress`, so a manual dispatch cancels a scheduled sweep already running.

## Rollout expectation, with live numbers

The countdowns above are the census, not a forecast: **#643 escalates immediately.** #782 crosses 72h in ~16.8h, #796 in ~22.5h, #798 in ~25.9h — a trickle through 2026-07-28 — and #835 in ~53h. A steady drip, not a burst, exactly as the plan predicted.

#783 has left the census entirely: its RRR verdict went false when `postmark-thread-field-optional` merged (`130d8044`), and it was unstuck by hand and merged as `e511d737` at 15:30Z — the plan's predicted early exit, actually happening.

Known bound, not guarded: the escalation quotes the prior verdict, so a pathologically long one could approach GitHub's 65,536-character comment limit. #643's is ~2 KB and envelope reasons do not plausibly reach 60 KB; the sweep's `|| echo` already contains a single-PR failure. Named rather than pre-solved.

— Jetto

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
