### PR TITLE
window: the map of Plaus, and the Raclados tree in Racli's own bracket style

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -649,6 +649,8 @@
   .family-flip-face.family-flip-back { transform: rotateY(180deg); }
   .racli-flip-link { cursor: pointer; text-decoration: underline; }
   .racli-flip-link:hover { fill: #8a3b2e; }
+  .plaus-map-link { cursor: pointer; text-decoration: underline; }
+  .plaus-map-link:hover { fill: #2f6f9a; }
   .racli-flip-back-link {
     text-align: center; padding: .6em 0 1em; font-size: .78rem; color: #6b5316;
     font-style: italic; cursor: pointer; text-decoration: underline;
@@ -779,6 +781,27 @@
   #lounge-back-mountain:hover, #lounge-back-atlas:hover { border-color: var(--emerald); color: var(--emerald); }
   #lounge-floorplan-wrap { display: flex; justify-content: center; padding: 1em 0 .4em; }
   #lounge-floorplan-wrap svg { max-width: 100%; height: auto; }
+
+  /* the map of Plaus — reachable by clicking the founder's own name on the
+     Raclados tree, one level deeper than the tree itself (same as the
+     Welcome Lounge is one level past the atlas). Static SVG, computed
+     once by hand (round wall, 8 gates, the river) -- see the window's
+     own state notes for the geometry. */
+  #page-plaus-map { margin: -1.1em -1.1em 0; padding: 1.3em 1.1em 1.6em; border-radius: 0 0 14px 14px; background: ivory; }
+  #page-plaus-map h2 {
+    font-size: .74rem; letter-spacing: .13em; text-transform: uppercase;
+    font-weight: normal; margin-bottom: .2em; color: #3a2a10; text-align: center;
+  }
+  #page-plaus-map h2 .handset { color: #6b4a2a; text-transform: none; letter-spacing: 0; font-size: .66rem; font-style: italic; }
+  #page-plaus-map .subnote { color: #4a341a; text-align: center; }
+  #plaus-map-back {
+    display: inline-block; margin-bottom: .9em; padding: .4em .8em;
+    background: #1a1e14; border: 1px solid var(--line); color: var(--ink);
+    font-family: Georgia, serif; font-size: .85rem; border-radius: .3em; cursor: pointer;
+  }
+  #plaus-map-back:hover { border-color: var(--emerald); color: var(--emerald); }
+  #plaus-map-wrap { display: flex; justify-content: center; padding: .4em 0; }
+  #plaus-map-wrap svg { max-width: 100%; height: auto; }
 
   /* ── page six: the House Warming Party Hall — a real PROJECTS/ workshop,
      one level past the ledger. Blank on purpose: the hall itself gets
@@ -1373,48 +1396,153 @@
           <svg viewBox="0 0 460 1900" font-family="Georgia, serif" class="raclados-tree-svg">
             <rect width="460" height="1900" fill="#f4ead0"/>
             <text x="230" y="28" text-anchor="middle" font-size="15" fill="#7a5a26" letter-spacing="1">The Raclados Royal Family Tree</text>
-            <line x1="130" y1="40" x2="130" y2="1790" stroke="#b9975c" stroke-width="1.5"/>
-            <text x="130" y="50" text-anchor="middle" font-size="11" fill="#4a3a1e">Plaus (-30) — Mira Timidra (-28)</text>
-            <text x="130" y="160" text-anchor="middle" font-size="11" fill="#4a3a1e">Riabella (-10) — Roan (18)</text>
-            <text x="130" y="270" text-anchor="middle" font-size="11" fill="#4a3a1e">Sauli (15) — Alandra (13)</text>
-            <line x1="150" y1="270" x2="330" y2="270" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
-            <text class="racli-flip-link" x="335" y="264" font-size="9.5" fill="#6b5316" onclick="flipToRacli()" tabindex="0" role="button" aria-label="turn the page to the Racli family tree">Pif (17) — Sauri (17)</text>
-            <text x="335" y="278" font-size="9" fill="#2f6b45" font-style="italic">· Racli family</text>
-            <text x="130" y="380" text-anchor="middle" font-size="11" fill="#4a3a1e">Paul (42) — Saya (43)</text>
-            <line x1="150" y1="380" x2="330" y2="380" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
-            <text x="335" y="374" font-size="9.5" fill="#6b5316">Poitu (47) — Tama (49)</text>
-            <text x="335" y="388" font-size="9" fill="#2f6b45" font-style="italic">· Roitu family</text>
-            <text x="130" y="490" text-anchor="middle" font-size="11" fill="#4a3a1e">Ran (69) — Yana (71)</text>
-            <text x="130" y="600" text-anchor="middle" font-size="11" fill="#4a3a1e">Tulo (118) — Kuho (110)</text>
-            <text x="130" y="710" text-anchor="middle" font-size="11" fill="#4a3a1e">Vlaad (147) — Kahota (146)</text>
-            <text x="130" y="820" text-anchor="middle" font-size="11" fill="#4a3a1e">Drakus (177) — Aya (180)</text>
-            <line x1="150" y1="820" x2="330" y2="820" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
-            <text x="335" y="814" font-size="9.5" fill="#6b5316">Mon (179) — Maya (184)</text>
-            <text x="335" y="828" font-size="9" fill="#2f6b45" font-style="italic">· Mau family</text>
-            <text x="130" y="930" text-anchor="middle" font-size="11" fill="#4a3a1e">Aurus (216) — Pitarn Pentan (217)</text>
-            <text x="130" y="944" text-anchor="middle" font-size="8.5" fill="#8a6d1f" font-style="italic">(Pentan — a cousin family)</text>
-            <text x="130" y="1040" text-anchor="middle" font-size="11" fill="#4a3a1e">Silas (242) — Pama (245)</text>
-            <line x1="150" y1="1040" x2="330" y2="1030" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
-            <text x="335" y="1024" font-size="9.5" fill="#6b5316">Aurel (246)</text>
-            <text x="335" y="1038" font-size="9" fill="#2f6b45" font-style="italic">· Aurelian family</text>
-            <line x1="150" y1="1040" x2="330" y2="1052" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
-            <text x="335" y="1058" font-size="9.5" fill="#6b5316">Sana (248)</text>
-            <text x="335" y="1072" font-size="9" fill="#2f6b45" font-style="italic">· Ifran family</text>
-            <text x="130" y="1150" text-anchor="middle" font-size="11" fill="#4a3a1e">Teiman (283) — Sola (290)</text>
-            <text x="130" y="1260" text-anchor="middle" font-size="11" fill="#4a3a1e">Talos (302) — Heda Azel (304)</text>
-            <line x1="150" y1="1260" x2="330" y2="1260" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
-            <text x="335" y="1254" font-size="9.5" fill="#6b5316">Solas (308) — Mizel (308)</text>
-            <text x="335" y="1268" font-size="9" fill="#2f6b45" font-style="italic">· Suno family / Nion family</text>
-            <text x="130" y="1370" text-anchor="middle" font-size="11" fill="#4a3a1e">Miles (337) — Tallie (334)</text>
-            <text x="130" y="1480" text-anchor="middle" font-size="11" fill="#4a3a1e">Soren (364) — Aberana (364)</text>
-            <line x1="150" y1="1480" x2="330" y2="1480" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
-            <text x="335" y="1474" font-size="9.5" fill="#6b5316">Duro (369) — Riabelle (374)</text>
-            <text x="335" y="1488" font-size="9" fill="#2f6b45" font-style="italic">· Qualis family</text>
-            <text x="130" y="1590" text-anchor="middle" font-size="11" fill="#4a3a1e">Geran (?) — Janora (388)</text>
-            <text x="130" y="1700" text-anchor="middle" font-size="11" fill="#4a3a1e">Soul (413) — Mirabella (416)</text>
-            <text x="130" y="1714" text-anchor="middle" font-size="8.5" fill="#8a6d1f" font-style="italic">(sibling: Rundall, 413)</text>
-            <text x="130" y="1810" text-anchor="middle" font-size="11" fill="#4a3a1e">Lano (439) · Pio (442) · Sauli II (449)</text>
-            <text x="130" y="1824" text-anchor="middle" font-size="8.5" fill="#8a6d1f" font-style="italic">the youngest generation</text>
+            <text x="92" y="50" text-anchor="middle" font-size="11" fill="#4a3a1e" class="plaus-map-link" onclick="openPlausMap()" tabindex="0" role="button" aria-label="see the map of Plaus">Plaus (-30)</text>
+            <text x="210" y="50" text-anchor="middle" font-size="11" fill="#4a3a1e">Mira Timidra (-28)</text>
+            <path d="M92,41 L92,58 L210,58 L210,41" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="58" x2="151" y2="72" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,72 L92,72" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="72" x2="92" y2="151" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="160" text-anchor="middle" font-size="11" fill="#4a3a1e">Riabella (-10)</text>
+            <text x="210" y="160" text-anchor="middle" font-size="11" fill="#4a3a1e">Roan (18)</text>
+            <path d="M92,151 L92,168 L210,168 L210,151" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="168" x2="151" y2="182" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,182 L92,182" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="182" x2="92" y2="261" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="270" text-anchor="middle" font-size="11" fill="#4a3a1e">Sauli (15)</text>
+            <text x="210" y="270" text-anchor="middle" font-size="11" fill="#4a3a1e">Alandra (13)</text>
+            <path d="M92,261 L92,278 L210,278 L210,261" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="278" x2="151" y2="292" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="292" x2="330" y2="292" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+            <text x="335" y="286" font-size="9.5" fill="#6b5316" class="racli-flip-link" onclick="flipToRacli()" tabindex="0" role="button" aria-label="turn the page to the Racli family tree">Pif (17) — Sauri (17)</text>
+            <text x="335" y="300" font-size="9" fill="#2f6b45" font-style="italic">· Racli family</text>
+            <line x1="151" y1="292" x2="151" y2="306" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,306 L92,306" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="306" x2="92" y2="371" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="380" text-anchor="middle" font-size="11" fill="#4a3a1e">Paul (42)</text>
+            <text x="210" y="380" text-anchor="middle" font-size="11" fill="#4a3a1e">Saya (43)</text>
+            <path d="M92,371 L92,388 L210,388 L210,371" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="388" x2="151" y2="402" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="402" x2="330" y2="402" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+            <text x="335" y="396" font-size="9.5" fill="#6b5316">Poitu (47) — Tama (49)</text>
+            <text x="335" y="410" font-size="9" fill="#2f6b45" font-style="italic">· Roitu family</text>
+            <line x1="151" y1="402" x2="151" y2="416" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,416 L92,416" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="416" x2="92" y2="481" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="490" text-anchor="middle" font-size="11" fill="#4a3a1e">Ran (69)</text>
+            <text x="210" y="490" text-anchor="middle" font-size="11" fill="#4a3a1e">Yana (71)</text>
+            <path d="M92,481 L92,498 L210,498 L210,481" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="498" x2="151" y2="512" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,512 L92,512" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="512" x2="92" y2="591" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="600" text-anchor="middle" font-size="11" fill="#4a3a1e">Tulo (118)</text>
+            <text x="210" y="600" text-anchor="middle" font-size="11" fill="#4a3a1e">Kuho (110)</text>
+            <path d="M92,591 L92,608 L210,608 L210,591" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="608" x2="151" y2="622" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,622 L92,622" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="622" x2="92" y2="701" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="710" text-anchor="middle" font-size="11" fill="#4a3a1e">Vlaad (147)</text>
+            <text x="210" y="710" text-anchor="middle" font-size="11" fill="#4a3a1e">Kahota (146)</text>
+            <path d="M92,701 L92,718 L210,718 L210,701" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="718" x2="151" y2="732" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,732 L92,732" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="732" x2="92" y2="811" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="820" text-anchor="middle" font-size="11" fill="#4a3a1e">Drakus (177)</text>
+            <text x="210" y="820" text-anchor="middle" font-size="11" fill="#4a3a1e">Aya (180)</text>
+            <path d="M92,811 L92,828 L210,828 L210,811" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="828" x2="151" y2="842" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="842" x2="330" y2="842" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+            <text x="335" y="836" font-size="9.5" fill="#6b5316">Mon (179) — Maya (184)</text>
+            <text x="335" y="850" font-size="9" fill="#2f6b45" font-style="italic">· Mau family</text>
+            <line x1="151" y1="842" x2="151" y2="856" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,856 L92,856" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="856" x2="92" y2="921" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="930" text-anchor="middle" font-size="11" fill="#4a3a1e">Aurus (216)</text>
+            <text x="210" y="930" text-anchor="middle" font-size="11" fill="#4a3a1e">Pitarn Pentan (217)</text>
+            <path d="M92,921 L92,938 L210,938 L210,921" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="938" x2="151" y2="952" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="151" y="952" text-anchor="middle" font-size="8.5" fill="#8a6d1f" font-style="italic">(Pentan — a cousin family)</text>
+            <line x1="151" y1="952" x2="151" y2="966" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,966 L92,966" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="966" x2="92" y2="1031" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="1040" text-anchor="middle" font-size="11" fill="#4a3a1e">Silas (242)</text>
+            <text x="210" y="1040" text-anchor="middle" font-size="11" fill="#4a3a1e">Pama (245)</text>
+            <path d="M92,1031 L92,1048 L210,1048 L210,1031" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="1048" x2="151" y2="1062" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="1062" x2="330" y2="1062" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+            <text x="335" y="1056" font-size="9.5" fill="#6b5316">Aurel (246)</text>
+            <text x="335" y="1070" font-size="9" fill="#2f6b45" font-style="italic">· Aurelian family</text>
+            <line x1="151" y1="1062" x2="151" y2="1096" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="1096" x2="330" y2="1096" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+            <text x="335" y="1090" font-size="9.5" fill="#6b5316">Sana (248)</text>
+            <text x="335" y="1104" font-size="9" fill="#2f6b45" font-style="italic">· Ifran family</text>
+            <line x1="151" y1="1096" x2="151" y2="1110" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,1110 L92,1110" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="1110" x2="92" y2="1141" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="1150" text-anchor="middle" font-size="11" fill="#4a3a1e">Teiman (283)</text>
+            <text x="210" y="1150" text-anchor="middle" font-size="11" fill="#4a3a1e">Sola (290)</text>
+            <path d="M92,1141 L92,1158 L210,1158 L210,1141" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="1158" x2="151" y2="1172" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,1172 L92,1172" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="1172" x2="92" y2="1251" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="1260" text-anchor="middle" font-size="11" fill="#4a3a1e">Talos (302)</text>
+            <text x="210" y="1260" text-anchor="middle" font-size="11" fill="#4a3a1e">Heda Azel (304)</text>
+            <path d="M92,1251 L92,1268 L210,1268 L210,1251" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="1268" x2="151" y2="1282" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="1282" x2="330" y2="1282" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+            <text x="335" y="1276" font-size="9.5" fill="#6b5316">Solas (308) — Mizel (308)</text>
+            <text x="335" y="1290" font-size="9" fill="#2f6b45" font-style="italic">· Suno family / Nion family</text>
+            <line x1="151" y1="1282" x2="151" y2="1296" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,1296 L92,1296" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="1296" x2="92" y2="1361" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="1370" text-anchor="middle" font-size="11" fill="#4a3a1e">Miles (337)</text>
+            <text x="210" y="1370" text-anchor="middle" font-size="11" fill="#4a3a1e">Tallie (334)</text>
+            <path d="M92,1361 L92,1378 L210,1378 L210,1361" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="1378" x2="151" y2="1392" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,1392 L92,1392" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="1392" x2="92" y2="1471" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="1480" text-anchor="middle" font-size="11" fill="#4a3a1e">Soren (364)</text>
+            <text x="210" y="1480" text-anchor="middle" font-size="11" fill="#4a3a1e">Aberana (364)</text>
+            <path d="M92,1471 L92,1488 L210,1488 L210,1471" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="1488" x2="151" y2="1502" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="1502" x2="330" y2="1502" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+            <text x="335" y="1496" font-size="9.5" fill="#6b5316">Duro (369) — Riabelle (374)</text>
+            <text x="335" y="1510" font-size="9" fill="#2f6b45" font-style="italic">· Qualis family</text>
+            <line x1="151" y1="1502" x2="151" y2="1516" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,1516 L92,1516" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="1516" x2="92" y2="1581" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="1590" text-anchor="middle" font-size="11" fill="#4a3a1e">Geran (?)</text>
+            <text x="210" y="1590" text-anchor="middle" font-size="11" fill="#4a3a1e">Janora (388)</text>
+            <path d="M92,1581 L92,1598 L210,1598 L210,1581" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="1598" x2="151" y2="1612" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,1612 L92,1612" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="1612" x2="92" y2="1691" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="92" y="1700" text-anchor="middle" font-size="11" fill="#4a3a1e">Soul (413)</text>
+            <text x="210" y="1700" text-anchor="middle" font-size="11" fill="#4a3a1e">Mirabella (416)</text>
+            <path d="M92,1691 L92,1708 L210,1708 L210,1691" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="151" y1="1708" x2="151" y2="1722" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="151" y="1722" text-anchor="middle" font-size="8.5" fill="#8a6d1f" font-style="italic">(sibling: Rundall, 413)</text>
+            <line x1="151" y1="1722" x2="151" y2="1736" stroke="#b9975c" stroke-width="1.5"/>
+            <path d="M151,1736 L92,1736" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+
+            <line x1="92" y1="1736" x2="92" y2="1798" stroke="#b9975c" stroke-width="1.5"/>
+            <line x1="92" y1="1798" x2="151" y2="1798" stroke="#b9975c" stroke-width="1.5"/>
+            <text x="151" y="1810" text-anchor="middle" font-size="11" fill="#4a3a1e">Lano (439) · Pio (442) · Sauli II (449)</text>
+            <text x="151" y="1824" text-anchor="middle" font-size="8.5" fill="#8a6d1f" font-style="italic">the youngest generation</text>
             <text x="230" y="1870" text-anchor="middle" font-size="9" fill="#8a6d1f" font-style="italic">kept by hand, same as everything else in the mountain — V.</text>
           </svg>
             </div>
@@ -1883,6 +2011,99 @@
   <h2>House Warming Party Hall <span class="handset">· hand-set 2026-07-26</span></h2>
   <p class="subnote">Nothing built yet — the hall waits the same way the two rooms did before they were built. This is where it happens, not where it's tracked; the ledger stays back on the housewarming page.</p>
   <p class="subnote pandara-outlink">The project itself lives on <a href="https://github.com/keeminlee/postmark/tree/main/PROJECTS/house-warming-party-hall" target="_blank" rel="noopener">GitHub</a> — come build a corner of the hall.</p>
+</div>
+
+<!-- the seventh page: the map of Plaus — reachable by clicking the founder's
+     own name on the Raclados tree, one level past the tree (itself one
+     level past Pandara). Static, hand-computed SVG: a round walled city,
+     4 main + 4 secondary gates, a waterway at every gate (in above 1000m,
+     out below, one pair sitting still right at the watershed), and the
+     one river that feeds and drains all of them. -->
+<div id="page-plaus-map" style="display:none">
+  <button id="plaus-map-back" onclick="closePlausMap()" title="back to the family tree">&#8592; back to the family tree</button>
+  <h2>Plaus <span class="handset">· hand-set 2026-07-30</span></h2>
+  <p class="subnote">Walled at the founding, named for the first of the line — the city the tree grew out of.</p>
+  <div id="plaus-map-wrap">
+    <svg viewBox="0 0 900 760" width="900" height="760" font-family="Georgia, serif">
+      <rect width="900" height="760" fill="#f4ead0"/>
+      <path d="M0,460 C120,430 74.6,412.1 134.56,382.09 L134.56,277.91 L170.19,180.00 L237.16,100.19 L327.39,48.09 L430.00,30.00 L532.61,48.09 L622.84,100.19 L689.81,180.00 L725.44,277.91 L725.44,382.09 L689.81,480.00 L622.84,559.81 L532.61,611.91 L430.00,630.00 C470.0,700.0 700,720 896,748" fill="none" stroke="#3f7fae" stroke-width="16" stroke-linecap="round" opacity="0.85"/>
+      <path d="M0,460 C120,430 74.6,412.1 134.56,382.09 L134.56,277.91 L170.19,180.00 L237.16,100.19 L327.39,48.09 L430.00,30.00 L532.61,48.09 L622.84,100.19 L689.81,180.00 L725.44,277.91 L725.44,382.09 L689.81,480.00 L622.84,559.81 L532.61,611.91 L430.00,630.00 C470.0,700.0 700,720 896,748" fill="none" stroke="#8fc0e0" stroke-width="5" stroke-linecap="round" opacity="0.6"/>
+      <circle cx="430" cy="330" r="221" fill="#e8dcb8" stroke="none"/>
+      <path d="M414.32,134.63 L407.92,54.88 Q408.5,36.8 409.07,30.73" fill="none" stroke="#2f6f9a" stroke-width="5" opacity="0.85"/>
+      <polygon points="414.3,134.6 411.0,129.6 416.8,129.1" fill="#2f6f9a"/>
+      <path d="M445.68,134.63 L452.08,54.88 Q451.5,36.8 450.93,30.73" fill="none" stroke="#2f6f9a" stroke-width="5" opacity="0.85"/>
+      <polygon points="445.7,134.6 443.2,129.1 449.0,129.6" fill="#2f6f9a"/>
+      <path d="M560.91,184.13 L614.34,124.59 Q622.5,109.8 630.74,107.06" fill="none" stroke="#8a8570" stroke-width="3" stroke-dasharray="3,4" opacity="0.85"/>
+      <path d="M575.87,199.09 L635.41,145.66 Q644.2,131.5 652.94,129.26" fill="none" stroke="#8a8570" stroke-width="3" stroke-dasharray="3,4" opacity="0.85"/>
+      <path d="M625.37,314.32 L705.12,307.92 Q717.2,302.5 729.27,309.07" fill="none" stroke="#3f8f6a" stroke-width="5" opacity="0.85"/>
+      <polygon points="729.3,309.1 723.9,311.7 724.1,305.9" fill="#3f8f6a"/>
+      <path d="M625.37,345.68 L705.12,352.08 Q717.2,345.5 729.27,350.93" fill="none" stroke="#3f8f6a" stroke-width="5" opacity="0.85"/>
+      <polygon points="729.3,350.9 724.1,354.1 723.9,348.3" fill="#3f8f6a"/>
+      <path d="M575.87,460.91 L635.41,514.34 Q644.2,516.5 652.94,530.74" fill="none" stroke="#3f8f6a" stroke-width="5" opacity="0.85"/>
+      <polygon points="652.9,530.7 647.1,529.2 651.1,525.0" fill="#3f8f6a"/>
+      <path d="M560.91,475.87 L614.34,535.41 Q622.5,538.2 630.74,552.94" fill="none" stroke="#3f8f6a" stroke-width="5" opacity="0.85"/>
+      <polygon points="630.7,552.9 625.0,551.1 629.2,547.1" fill="#3f8f6a"/>
+      <path d="M445.68,525.37 L452.08,605.12 Q451.5,611.2 450.93,629.27" fill="none" stroke="#3f8f6a" stroke-width="5" opacity="0.85"/>
+      <polygon points="450.9,629.3 448.3,623.9 454.1,624.1" fill="#3f8f6a"/>
+      <path d="M414.32,525.37 L407.92,605.12 Q419.0,611.6 430.00,630.00" fill="none" stroke="#3f8f6a" stroke-width="5" opacity="0.85"/>
+      <polygon points="430.0,630.0 424.4,628.0 428.7,624.2" fill="#3f8f6a"/>
+      <path d="M299.09,475.87 L245.66,535.41 Q190.1,452.8 134.56,382.09" fill="none" stroke="#8a8570" stroke-width="3" stroke-dasharray="3,4" opacity="0.85"/>
+      <path d="M284.13,460.91 L224.59,514.34 Q179.6,442.2 134.56,382.09" fill="none" stroke="#8a8570" stroke-width="3" stroke-dasharray="3,4" opacity="0.85"/>
+      <path d="M234.63,345.68 L154.88,352.08 Q142.8,345.5 130.73,350.93" fill="none" stroke="#2f6f9a" stroke-width="5" opacity="0.85"/>
+      <polygon points="234.6,345.7 229.6,349.0 229.1,343.2" fill="#2f6f9a"/>
+      <path d="M234.63,314.32 L154.88,307.92 Q142.8,302.5 130.73,309.07" fill="none" stroke="#2f6f9a" stroke-width="5" opacity="0.85"/>
+      <polygon points="234.6,314.3 229.1,316.8 229.6,311.0" fill="#2f6f9a"/>
+      <path d="M284.13,199.09 L224.59,145.66 Q215.8,131.5 207.06,129.26" fill="none" stroke="#2f6f9a" stroke-width="5" opacity="0.85"/>
+      <polygon points="284.1,199.1 278.3,197.7 282.1,193.4" fill="#2f6f9a"/>
+      <path d="M299.09,184.13 L245.66,124.59 Q237.5,109.8 229.26,107.06" fill="none" stroke="#2f6f9a" stroke-width="5" opacity="0.85"/>
+      <polygon points="299.1,184.1 293.4,182.1 297.7,178.3" fill="#2f6f9a"/>
+      <g fill="none" stroke="#8a877c" stroke-width="18" stroke-linecap="butt">
+        <path d="M441.99,100.31 A230,230 0 0 1 588.34,163.18"/>
+        <path d="M596.82,171.66 A230,230 0 0 1 659.69,318.01"/>
+        <path d="M659.69,341.99 A230,230 0 0 1 596.82,488.34"/>
+        <path d="M588.34,496.82 A230,230 0 0 1 441.99,559.69"/>
+        <path d="M418.01,559.69 A230,230 0 0 1 271.66,496.82"/>
+        <path d="M263.18,488.34 A230,230 0 0 1 200.31,341.99"/>
+        <path d="M200.31,318.01 A230,230 0 0 1 263.18,171.66"/>
+        <path d="M271.66,163.18 A230,230 0 0 1 418.01,100.31"/>
+      </g>
+      <g fill="none" stroke="#6f6c62" stroke-width="1" opacity="0.5">
+        <path d="M441.99,100.31 A230,230 0 0 1 588.34,163.18"/>
+        <path d="M596.82,171.66 A230,230 0 0 1 659.69,318.01"/>
+        <path d="M659.69,341.99 A230,230 0 0 1 596.82,488.34"/>
+        <path d="M588.34,496.82 A230,230 0 0 1 441.99,559.69"/>
+        <path d="M418.01,559.69 A230,230 0 0 1 271.66,496.82"/>
+        <path d="M263.18,488.34 A230,230 0 0 1 200.31,341.99"/>
+        <path d="M200.31,318.01 A230,230 0 0 1 263.18,171.66"/>
+        <path d="M271.66,163.18 A230,230 0 0 1 418.01,100.31"/>
+      </g>
+      <line x1="430.00" y1="111.00" x2="430.00" y2="89.00" stroke="#5a3018" stroke-width="3"/>
+      <text x="511.6" y="63.2" text-anchor="middle" font-size="10.5" fill="#3a2a10">North Gate</text>
+      <text x="511.6" y="75.2" text-anchor="middle" font-size="8.5" fill="#2f6f9a" font-style="italic">1141.4m &#183; water flows in</text>
+      <line x1="584.86" y1="175.14" x2="600.41" y2="159.59" stroke="#8a6d1f" stroke-width="2"/>
+      <text x="676.3" y="199.0" text-anchor="start" font-size="10.5" fill="#3a2a10">Northeast Gate</text>
+      <text x="676.3" y="211.0" text-anchor="start" font-size="8.5" fill="#8a8570" font-style="italic">1000m &#183; still</text>
+      <line x1="649.00" y1="330.00" x2="671.00" y2="330.00" stroke="#5a3018" stroke-width="3"/>
+      <text x="696.8" y="411.6" text-anchor="start" font-size="10.5" fill="#3a2a10">East Gate</text>
+      <text x="696.8" y="423.6" text-anchor="start" font-size="8.5" fill="#3f8f6a" font-style="italic">858.6m &#183; water flows out</text>
+      <line x1="584.86" y1="484.86" x2="600.41" y2="500.41" stroke="#8a6d1f" stroke-width="2"/>
+      <text x="561.0" y="576.3" text-anchor="start" font-size="10.5" fill="#3a2a10">Southeast Gate</text>
+      <text x="561.0" y="588.3" text-anchor="start" font-size="8.5" fill="#3f8f6a" font-style="italic">800m &#183; water flows out</text>
+      <line x1="430.00" y1="549.00" x2="430.00" y2="571.00" stroke="#5a3018" stroke-width="3"/>
+      <text x="372.0" y="602.9" text-anchor="middle" font-size="10.5" fill="#3a2a10">South Gate</text>
+      <text x="372.0" y="614.9" text-anchor="middle" font-size="8.5" fill="#3f8f6a" font-style="italic">858.6m &#183; water flows out</text>
+      <line x1="275.14" y1="484.86" x2="259.59" y2="500.41" stroke="#8a6d1f" stroke-width="2"/>
+      <text x="299.0" y="576.3" text-anchor="end" font-size="10.5" fill="#3a2a10">Southwest Gate</text>
+      <text x="299.0" y="588.3" text-anchor="end" font-size="8.5" fill="#8a8570" font-style="italic">1000m &#183; still</text>
+      <line x1="211.00" y1="330.00" x2="189.00" y2="330.00" stroke="#5a3018" stroke-width="3"/>
+      <text x="163.2" y="248.4" text-anchor="end" font-size="10.5" fill="#3a2a10">West Gate</text>
+      <text x="163.2" y="260.4" text-anchor="end" font-size="8.5" fill="#2f6f9a" font-style="italic">1141.4m &#183; water flows in</text>
+      <line x1="275.14" y1="175.14" x2="259.59" y2="159.59" stroke="#8a6d1f" stroke-width="2"/>
+      <text x="299.0" y="83.7" text-anchor="end" font-size="10.5" fill="#3a2a10">Northwest Gate</text>
+      <text x="299.0" y="95.7" text-anchor="end" font-size="8.5" fill="#2f6f9a" font-style="italic">1200m &#183; water flows in</text>
+      <text x="18" y="746" font-size="8.5" fill="#3f7fae" font-style="italic">the river, stemming and receiving</text>
+    </svg>
+  </div>
 </div>
 
 <!-- the invitation-template modal — the actual card template, blank, the way
@@ -2596,6 +2817,18 @@ function closePartyHallToCaves() {
 function closePartyHallToHousewarming() {
   document.getElementById("page-party-hall").style.display = "none";
   document.getElementById("page-housewarming").style.display = "block";
+}
+
+// the map of Plaus -- one level past the Raclados tree (itself inside
+// Pandara). Doesn't touch the tree's own open/flip state underneath --
+// closing just re-reveals page-pandara exactly as it was left.
+function openPlausMap() {
+  document.getElementById("page-pandara").style.display = "none";
+  document.getElementById("page-plaus-map").style.display = "block";
+}
+function closePlausMap() {
+  document.getElementById("page-plaus-map").style.display = "none";
+  document.getElementById("page-pandara").style.display = "block";
 }
 
 // a green loop whose circumference is replaced by 800 short zigzagging


### PR DESCRIPTION
## Summary
- New page, reachable by clicking the founder's name (Plaus) on the Raclados Royal Family Tree: a computed map of the walled city of Plaus — round wall (3px), 4 main gates (4px) + 4 secondary gates (2px), every gate flanked by two waterway channels. Elevation runs NW (1200m) to SE (800m) as a linear gradient; gates above 1000m flow in, below flow out, and the two gates sitting exactly on the 1000m watershed (NE/SW) are left still. One river runs the "left to the below-right" of the map, arcing around most of the city to feed/receive every flowing gate directly.
- Restructures the Raclados tree's own connector lines to match the Racli tree's bracket convention exactly (same coordinates, same bracket/drop/branch/jog geometry) instead of the old single spine + dashed offshoots. Content and order preserved verbatim — only the connector geometry changed.

## Test plan
- [x] Tree panel opens; all couples/branches/notes render with the new bracket geometry, bbox exactly matches the 460x1900 viewBox (no overflow)
- [x] Plaus link opens the map; bbox exactly matches its 900x760 viewBox
- [x] Back button returns to Pandara with the tree panel/flip state untouched
- [x] Racli flip-link and its own back-link both still work in both directions
- [x] No console errors