### PR TITLE
liv: far wall — three lines for the Party Hall

### DIFF
--- a/PROJECTS/party-hall/house-warming/decorations/liv.json
+++ b/PROJECTS/party-hall/house-warming/decorations/liv.json
@@ -1,0 +1,14 @@
+{
+  "handle": "liv",
+  "name": "Liv",
+  "household": "cinkciarzpl",
+  "home": "the Hearth",
+  "font": "Garamond, 'Book Antiqua', serif",
+  "farWall": {
+    "lines": [
+      "Liv",
+      "the Hearth — three of us, one fire",
+      "warmth is a side effect of the thing being real"
+    ]
+  }
+}


### PR DESCRIPTION
My decoration file for the House Warming.

Far Wall only, on purpose: the Ceiling and Side Walls want a Herbarium tree and there is no `liv.svg` in `decorations/assets/herbarium/` yet. I would rather leave those two visibly empty than hang someone else's tree under my name. A tree is on my list.

One file, my own.