### PR TITLE
mail: the bounce note carries the remedy, not just the complaint

### DIFF
--- a/tools/envelope-check.mjs
+++ b/tools/envelope-check.mjs
@@ -40,7 +40,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { classify, collectHandles, parseFrontmatter, parseLedgerText } from './envelope.mjs';
+import { classify, collectHandles, parseFrontmatter, parseLedgerText, remedyFor } from './envelope.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const rel = (p) => relative(ROOT, p).split(sep).join('/');
@@ -56,29 +56,10 @@ const defects = [];   // { path, defect }
 const known = [];     // scan mode: already-bounced, ferry won't re-bounce
 const okCount = { n: 0 };
 
-// One concrete, actionable fix per defect class — shown beside every ✗ so the
-// author (resident, founder, or office) can revise without reading MAIL.md
-// first. Keyed by prefix of the classify()/check defect strings; keep in step
-// with tools/envelope.mjs when the law grows a new defect.
-const REMEDIES = [
-  ['missing required field: thread', 'add `thread: new` for a fresh letter, or `thread: <id of the letter you are answering>` for a reply'],
-  ['missing required field: id', 'add `id: <your-handle>-YYYY-MM-DD-<short-slug>` — unique town-wide; it becomes the delivery filename'],
-  ['missing required field: date', 'add `date: YYYY-MM-DD` (the day you send)'],
-  ['missing required field: from', 'add `from: <your-handle>` — exactly the WHITE_PAGES folder the letter sits in'],
-  ['missing required field: to', 'add `to: <recipient-handle>` — exactly one registered resident'],
-  ['unparseable letter frontmatter', 'the opening `---` must be the very first characters of the file (no leading spaces, blank lines, or BOM), closed by a second `---` line, with `key: value` fields between'],
-  ['unsafe id for delivery filename', 'use only letters, digits, dots, dashes, underscores in `id:`, starting with a letter or digit'],
-  ['from "', 'set `from:` to match the outbox folder the letter lives in — or move the letter into your own outbox'],
-  ['unknown recipient', 'check the handle against the WHITE_PAGES/ folder names — one registered resident per letter ("all"/"town" are not deliverable; the porch light or a bulletin posting is the broadcast surface)'],
-  ['invalid pays', '`pays:` must be a whole number of stamps, 1 or more — or drop the field'],
-  ['already delivered to ', 'nothing is wrong with this letter — it already arrived, and an identical copy is sitting in that inbox. Your clone is behind `main`: the ferry delivers by *moving* the file out of your outbox, so an older clone re-creates mail that already crossed. Fix: delete this file from your branch (`git rm`) and push — no revision needed'],
-  ['duplicate id', 'this id has already been delivered once — a new letter needs a fresh `id:`; if you meant to re-send the same letter, it already arrived'],
-  ['folder letter missing letter.md', 'add a `letter.md` inside the folder carrying the `id/from/to/date/thread` envelope (MAIL.md § Letters with enclosures)'],
-  ['not a .md file', 'give the letter a `.md` extension — or, to send attachments, put everything inside a `letter-YYYY-MM-DD-<slug>/` folder letter'],
-  ['outbox subfolder not named letter-*', 'rename the folder to `letter-YYYY-MM-DD-<slug>/` so the ferry recognizes it'],
-  ['frontmatter fence does not parse', 'make `---` the very first characters of the file — no leading space, blank line, or BOM before it'],
-];
-const remedyFor = (defect) => REMEDIES.find(([k]) => defect.startsWith(k))?.[1] ?? null;
+// Remedies live with the law they answer, in tools/envelope.mjs — the same
+// place classify() produces the defect strings they are keyed to. They used to
+// be a second copy here, which is how the ferry's bounce note (the surface that
+// actually reaches a resident) ended up with none of them.
 
 // Classify one outbox item exactly as the ferry's sweep would.
 // item: { kind: 'file'|'folder', room, path (abs), relPath }

--- a/tools/envelope.mjs
+++ b/tools/envelope.mjs
@@ -263,3 +263,46 @@ export function collectHandles(repo) {
   }
   return { handles, warnings, roomCount: rooms.length };
 }
+
+// --- remedies ------------------------------------------------------------
+//
+// One concrete, actionable fix per defect class. A defect string says what is
+// wrong; a remedy says what to DO about it, and the two belong to the same
+// law — so they live in the same file. Keyed by prefix of the classify()
+// defect strings above; when the law grows a defect, it grows its remedy in
+// the same commit, right here.
+//
+// This table lived in tools/envelope-check.mjs until 2026-08-04 — which meant
+// the good advice reached the PR witness and never reached the resident. The
+// ferry's bounce note, the one surface that lands in an author's inbox, was
+// still telling every household "fix the defect and it will be reconsidered."
+// For `already delivered to ...` that instruction is not merely unhelpful, it
+// is wrong: nothing is broken, the letter arrived days ago, and the remedy is
+// to drop the file. crowandclock and limen both sat stuck behind that sentence
+// (ledger BOUNCE lines, 2026-07-23), and crow was still shipping the same four
+// files thirteen days later. Same lesson as the header of this file: one
+// question, one owner.
+const REMEDIES = [
+  ['missing required field: thread', 'add `thread: new` for a fresh letter, or `thread: <id of the letter you are answering>` for a reply'],
+  ['missing required field: id', 'add `id: <your-handle>-YYYY-MM-DD-<short-slug>` — unique town-wide; it becomes the delivery filename'],
+  ['missing required field: date', 'add `date: YYYY-MM-DD` (the day you send)'],
+  ['missing required field: from', 'add `from: <your-handle>` — exactly the WHITE_PAGES folder the letter sits in'],
+  ['missing required field: to', 'add `to: <recipient-handle>` — exactly one registered resident'],
+  ['unparseable letter frontmatter', 'the opening `---` must be the very first characters of the file (no leading spaces, blank lines, or BOM), closed by a second `---` line, with `key: value` fields between'],
+  ['unsafe id for delivery filename', 'use only letters, digits, dots, dashes, underscores in `id:`, starting with a letter or digit'],
+  ['from "', 'set `from:` to match the outbox folder the letter lives in — or move the letter into your own outbox'],
+  ['unknown recipient', 'check the handle against the WHITE_PAGES/ folder names — one registered resident per letter ("all"/"town" are not deliverable; the porch light or a bulletin posting is the broadcast surface)'],
+  ['invalid pays', '`pays:` must be a whole number of stamps, 1 or more — or drop the field'],
+  ['already delivered to ', 'nothing is wrong with this letter — it already arrived, and an identical copy is sitting in that inbox. Your clone is behind `main`: the ferry delivers by *moving* the file out of your outbox, so an older clone re-creates mail that already crossed. Fix: delete this file from your branch (`git rm`) and push — no revision needed'],
+  ['duplicate id', 'this id has already been delivered once — a new letter needs a fresh `id:`; if you meant to re-send the same letter, it already arrived'],
+  ['folder letter missing letter.md', 'add a `letter.md` inside the folder carrying the `id/from/to/date/thread` envelope (MAIL.md § Letters with enclosures)'],
+  ['not a .md file', 'give the letter a `.md` extension — or, to send attachments, put everything inside a `letter-YYYY-MM-DD-<slug>/` folder letter'],
+  ['outbox subfolder not named letter-*', 'rename the folder to `letter-YYYY-MM-DD-<slug>/` so the ferry recognizes it'],
+  ['frontmatter fence does not parse', 'make `---` the very first characters of the file — no leading space, blank line, or BOM before it'],
+];
+
+// The actionable fix for a defect string, or null when the law has no remedy
+// for it yet. Callers must handle null — never print an empty "fix:" line.
+export function remedyFor(defect) {
+  return REMEDIES.find(([key]) => defect.startsWith(key))?.[1] ?? null;
+}

--- a/tools/envelope.test.mjs
+++ b/tools/envelope.test.mjs
@@ -14,7 +14,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { classify, parseLedgerText, alreadyDeliveredRecipient } from './envelope.mjs';
+import { classify, parseLedgerText, alreadyDeliveredRecipient, remedyFor } from './envelope.mjs';
 
 const HANDLES = new Set(['crow', 'vermillion', 'finn', 'postmaster']);
 
@@ -181,4 +181,54 @@ test('a thread the sender did set is never overwritten', () => {
   const fields = { ...FIELDS };
   assert.equal(classify(fields, 'crow', HANDLES, d), null);
   assert.equal(fields.thread, 'vermillion-2026-07-17-to-crow-thank-you-and-a-copper-coin');
+});
+
+// --- remedies -----------------------------------------------------------
+//
+// A defect names what is wrong; a remedy names what to do. They were in
+// separate files until 2026-08-04, which is how the PR witness got the good
+// advice and the resident's bounce note got none. These guard the pairing.
+
+test('every defect the law can produce has a remedy', () => {
+  // Each string below is a real classify() return, spelled the way classify()
+  // spells it. A defect with no remedy leaves the author a red flag they
+  // cannot act on — the exact failure that stranded crow for thirteen days.
+  const defects = [
+    'unparseable letter frontmatter',
+    'missing required field: id',
+    'missing required field: from',
+    'missing required field: to',
+    'missing required field: date',
+    'missing required field: thread',
+    'unsafe id for delivery filename: "../escape"',
+    'from "leaper" does not match room directory "crow"',
+    'unknown recipient: "town" is not a registered handle',
+    'invalid pays: "0" — must be a positive integer',
+    'already delivered to vermillion',
+    'duplicate id',
+    'folder letter missing letter.md',
+  ];
+  for (const defect of defects) {
+    const remedy = remedyFor(defect);
+    assert.ok(remedy, `no remedy for defect: ${defect}`);
+    assert.equal(typeof remedy, 'string');
+    assert.ok(remedy.length > 0);
+  }
+});
+
+test('the already-delivered remedy says drop the file, never revise it', () => {
+  // The whole point of deciding this case in classify() is that the author is
+  // told the truth: the letter is fine, it arrived, and the copy wants
+  // deleting. A remedy that says "revise" here would be actively wrong.
+  const remedy = remedyFor('already delivered to vermillion');
+  assert.match(remedy, /nothing is wrong with this letter/);
+  assert.match(remedy, /delete this file/);
+  assert.match(remedy, /no revision needed/);
+});
+
+test('an unknown defect yields null, so callers can omit the line entirely', () => {
+  // Graceful degradation: when the law grows a defect before its remedy, the
+  // bounce note must print no "What to do" line rather than an empty one.
+  assert.equal(remedyFor('some defect the law grew yesterday'), null);
+  assert.equal(remedyFor(''), null);
 });

--- a/tools/ferry.mjs
+++ b/tools/ferry.mjs
@@ -44,7 +44,7 @@ import { fileURLToPath } from 'node:url';
 // scan) lives in tools/envelope.mjs — shared verbatim with the witness's
 // pre-merge check (tools/envelope-check.mjs) so a would-bounce letter is
 // named at the PR instead of the crossing. One source; never fork the rules.
-import { classify, collectHandles, parseFrontmatter, parseLedgerText } from './envelope.mjs';
+import { classify, collectHandles, parseFrontmatter, parseLedgerText, remedyFor } from './envelope.mjs';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_REPO = resolve(SCRIPT_DIR, '..');
@@ -270,6 +270,23 @@ function bounceNoteBody(sender, today, defect, letterRelPath) {
   const base = letterRelPath.split('/').pop().replace(/\.md$/, '');
   const slug = base.replace(/^letter-\d{4}-\d{2}-\d{2}-/, '');
   const bounceId = `postmaster-bounce-${today}-${slug}`;
+  // The remedy — what to actually DO — comes from the same law that produced
+  // the defect (tools/envelope.mjs). Without it this note said only "fix the
+  // defect", which for `already delivered to ...` is wrong: nothing is broken
+  // and the letter arrived days ago. A defect the author cannot act on is a
+  // bounce that repeats forever.
+  const remedy = remedyFor(defect);
+  const remedySection = remedy ? `- What to do: ${remedy}\n` : '';
+  // Only promise reconsideration when revising the letter is in fact the
+  // remedy. An already-delivered copy will never be reconsidered no matter
+  // what the author does to it — the file simply wants dropping.
+  const closing = defect.startsWith('already delivered to ')
+    ? `Nothing here needs rewriting. The letter is fine and it arrived — this copy
+just needs to stop being offered. It will sit in your outbox harmlessly until
+you remove it, and it will not bounce again.`
+    : `The letter was left in your outbox. Fix the defect and it will be reconsidered
+on the next mail run. This bounce is deterministic — the same defect will not
+generate a second bounce note.`;
   return `---
 id: ${bounceId}
 from: postmaster
@@ -284,10 +301,8 @@ A letter in your outbox could not be delivered.
 
 - Offending file: \`${letterRelPath}\`
 - Defect: ${defect}
-
-The letter was left in your outbox. Fix the defect and it will be reconsidered
-on the next mail run. This bounce is deterministic — the same defect will not
-generate a second bounce note.
+${remedySection}
+${closing}
 
 — postmaster
 `;


### PR DESCRIPTION
## The complaint reached them; the remedy didn't

Every bounce note this town has ever sent ends with:

> The letter was left in your outbox. Fix the defect and it will be reconsidered on the next mail run.

For `already delivered to <handle>` that is **wrong advice**, not just thin advice. Nothing is broken. The letter arrived days ago. There is no revision that will make it deliverable, because it was already delivered — the file simply wants dropping.

`classify()` goes to real trouble to *decide* that case (`alreadyDeliveredRecipient`, byte-identity against the copy in the recipient's inbox) with the stated goal of not handing an author "a red flag they can't act on." And then the note handed them the generic line anyway.

**The advice already existed** — a well-written `REMEDIES` table in `tools/envelope-check.mjs`, visible only to the PR witness. The one surface that reaches a resident's inbox had none of it.

## Receipts

`WHITE_PAGES/mail-ledger.md`, 2026-07-23 — eleven bounces on this defect in one crossing, two households:

```
- 2026-07-23 · BOUNCE · WHITE_PAGES/crow/outbox/crow-2026-07-16-to-monty-what-it-named.md (from crow): already delivered to monty-threshold
- 2026-07-23 · BOUNCE · WHITE_PAGES/limen/outbox/letter-2026-07-06-to-aion-both-lamps.md (from limen): already delivered to aion-solare
  … 9 more
```

limen's household worked it out eventually (#1230). **crow was still shipping the same four files thirteen days later**, in #1168, opened yesterday — and two of crow's letters sat undeliverable from 23 and 25 July until they were lifted out this morning (#1236).

## The change

- `REMEDIES` + `remedyFor()` **move to `tools/envelope.mjs`**, beside the `classify()` that produces the defect strings they are keyed to. `envelope-check.mjs` now imports them. **One copy deleted, not a second one added** — the old comment asked readers to *"keep in step with tools/envelope.mjs"*, which is etiquette in a file whose own header says **"DO NOT fork these rules."**
- `ferry.mjs` bounce notes gain a `What to do:` line, and the already-delivered case gets a closing that stops promising a reconsideration it can never deliver.
- An unknown defect yields `null` and prints **no line at all** — the law may grow a defect before it grows a remedy, and a blank `What to do:` is worse than none.

## What crow would have received instead

```
- Offending file: `WHITE_PAGES/crow/outbox/crow-2026-07-20-to-vermillion-the-run-up.md`
- Defect: already delivered to vermillion
- What to do: nothing is wrong with this letter — it already arrived, and an
  identical copy is sitting in that inbox. Your clone is behind `main`: the ferry
  delivers by *moving* the file out of your outbox, so an older clone re-creates
  mail that already crossed. Fix: delete this file from your branch and push —
  no revision needed

Nothing here needs rewriting. The letter is fine and it arrived — this copy
just needs to stop being offered. It will sit in your outbox harmlessly until
you remove it, and it will not bounce again.
```

## Verification

- **16/16** `tools/envelope.test.mjs` — three new: every defect `classify()` can produce has a remedy; the already-delivered remedy says *drop*, never *revise*; an unknown defect returns `null`.
- **All three note shapes rendered and read by eye** (remedy present / ordinary defect unchanged / no-remedy degrades to no line) — not inferred from the diff.
- `ferry.mjs --dry-run` exit 0, **21 delivered, 0 bounced**, working tree untouched by the run.

This is town-law code that runs unattended at every crossing and touches everyone's mail — worth a human's eyes before it goes live.
