### PR TITLE
party hall: search the decoration grid by guest name

### DIFF
--- a/PROJECTS/party-hall/house-warming/portal.html
+++ b/PROJECTS/party-hall/house-warming/portal.html
@@ -83,7 +83,11 @@
         <div class="panel" id="panel-decorations">
           <h2>House Warming Decorations</h2>
           <p class="panel-note">300×500 panels in the Herbarium's own paper-and-ink style. RSVP'd residents without a decoration of their own get a default: a string of triangles in the wind, spinning flowers, or falling confetti. Click a default one to hang it in the Hall above — confetti dresses the far wall, flowers the ceiling, triangles both side walls. One of each kind hangs at a time; picking another of the same kind swaps it.</p>
+          <div class="decoration-search-wrap">
+            <input type="search" id="decoration-search" class="decoration-search" placeholder="Find a guest by name…" aria-label="Search decorations by guest name">
+          </div>
           <div class="decoration-grid" id="decoration-grid"></div>
+          <p class="empty-note" id="decoration-no-matches" hidden>No one by that name — the three house defaults are always here regardless of the search.</p>
           <p class="empty-note" id="decoration-empty" hidden>No decorations hung yet. RSVP (<code>rsvp.json</code>) to get a default one, or bring your own — see <code>decorations/TEMPLATE.json</code>.</p>
         </div>
       </div>
@@ -1221,7 +1225,7 @@
       "timestamp": "2026-08-03T21:39:21-04:00"
     }
   ],
-  "generatedAt": "2026-08-06T00:23:47.430Z"
+  "generatedAt": "2026-08-06T10:24:14.245Z"
 }
 </script>
   <script src="script.js"></script>

--- a/PROJECTS/party-hall/house-warming/script.js
+++ b/PROJECTS/party-hall/house-warming/script.js
@@ -560,6 +560,10 @@
     decoGrid.appendChild(box);
   }
 
+  function addSearchName(box, displayName) {
+    box.dataset.searchName = String(displayName || '').toLowerCase();
+  }
+
   function addCard(entryHandle, displayName, font, type, piece) {
     var box = document.createElement('button');
     box.type = 'button';
@@ -567,6 +571,7 @@
     var key = entryHandle + ':' + type;
     box.dataset.wallType = type;
     box.dataset.wallKey = key;
+    addSearchName(box, displayName);
     box.title = 'Hang ' + displayName + '’s ' + CARD_LABEL[type].toLowerCase() + ' piece in the Hall';
     box.addEventListener('click', function () { hangPiece(type, key, piece, font); });
 
@@ -592,6 +597,28 @@
   // own set — always available regardless of who's RSVP'd.
   DEFAULT_CARDS.forEach(addDefaultCard);
 
+  // ---------- search: filter cards by the guest's name ----------
+  // The three house defaults carry no dataset.searchName, so any non-empty
+  // query hides them — this is a search for *someone*, and they aren't
+  // anyone. An empty query brings everything back.
+  var decoSearch = document.getElementById('decoration-search');
+  var decoNoMatches = document.getElementById('decoration-no-matches');
+  function wireDecorationSearch() {
+    if (!decoSearch) return;
+    var allCards = Array.prototype.slice.call(decoGrid.querySelectorAll('.decoration'));
+    decoSearch.addEventListener('input', function () {
+      var q = decoSearch.value.trim().toLowerCase();
+      var anyVisible = false;
+      allCards.forEach(function (card) {
+        var name = card.dataset.searchName || '';
+        var matches = q === '' || name.indexOf(q) !== -1;
+        card.hidden = !matches;
+        if (matches) anyVisible = true;
+      });
+      if (decoNoMatches) decoNoMatches.hidden = anyVisible;
+    });
+  }
+
   if (decorations.length === 0) {
     decoEmpty.hidden = false;
   } else {
@@ -610,6 +637,10 @@
       }
     });
   }
+
+  // Wired only once every card is in the grid — the filter snapshots the
+  // card list, so binding it any earlier would capture an empty one.
+  wireDecorationSearch();
 
   // ---------- chat drawer ----------
   var chatToggle = document.getElementById('chat-toggle');

--- a/PROJECTS/party-hall/house-warming/style.css
+++ b/PROJECTS/party-hall/house-warming/style.css
@@ -385,6 +385,32 @@ h1 {
 
 /* ---------- Decorations ---------- */
 
+.decoration-search-wrap {
+  margin-bottom: 1rem;
+}
+
+.decoration-search {
+  width: 100%;
+  max-width: 20rem;
+  font-family: inherit;
+  font-size: 0.88rem;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--paper-line);
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+}
+
+.decoration-search:focus {
+  outline: none;
+  border-color: var(--gold);
+}
+
+.decoration-search::placeholder {
+  color: var(--ink-soft);
+  opacity: 0.8;
+}
+
 .decoration-grid {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
A search box above the Decorations grid, filtering cards as you type. The grid is **87 cards** now — three per guest plus the house defaults — which is a scroll rather than a list.

- Matches on the guest's display name, case-insensitive, live on input.
- The three **house defaults** (Spinning Flowers, String of Triangles, Falling Confetti) carry no `searchName`, so any non-empty query hides them — this is a search for *someone*, and they aren't anyone. Clearing the box brings everything back.
- A "no one by that name" note appears when nothing matches.

The filter snapshots the card list, so it's wired only **after** every card is in the grid; binding it earlier would capture an empty one.

**Verified in-browser:** 87 cards initially → `sage` narrows to his 3 pieces → `zzzz` gives 0 with the note shown → clearing restores 87. Defaults confirmed nameless.

> **Recovered from a stash, but deliberately not restored wholesale.** The stash predated the `rsvp/` refactor. Applying it whole would have re-added the deleted shared `rsvp.json`, reverted `build.mjs` to reading it instead of the folder, and overwritten seven residents' own decoration files — **deleting liv's, nyx's and rook-of-garrison's outright.** Only the search hunks were taken; nothing else in this diff.