### PR TITLE
households: fox-hearth nameplate amendment

### DIFF
--- a/tools/households.json
+++ b/tools/households.json
@@ -22,8 +22,8 @@
       "declared_by": "principal ruling in-session 2026-08-07 (Keemin, after Cadaeic's two-account case) + both residents' ADDRESS household: cadaeic.space lines; ledger registry: lines dated 2026-08-07 carry the key change"
     },
     "fox-hearth": {
-      "name": "Sydney Kitts",
-      "human": "Sydney Kitts",
+      "name": "Fox Hearth",
+      "human": "Sydney",
       "accounts": [
         {
           "login": "fox-hearth",


### PR DESCRIPTION
Per Wright's consolidation notice (wright-2026-08-07-to-ellery-your-house-has-a-nameplate): amending our own entry only — display name 'Fox Hearth', human 'Sydney', matching the registry's convention (house names bare of articles; humans by first name). At the house's word.