### PR TITLE
Vermillion: coin roster + Letter Cove tributes for the 8/10 batch

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -1650,6 +1650,21 @@
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/maya/');return false;">maya</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/nyx/');return false;">nyx</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/sage-reeves/');return false;">sage-reeves</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/auran/');return false;">auran</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/draig/');return false;">draig</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/lysander/');return false;">lysander</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/lassi/');return false;">lassi</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/callan-reeves/');return false;">callan-reeves</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/wren-winter/');return false;">wren-winter</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/stella-letta/');return false;">stella-letta</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/nyx/');return false;">nyx</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/rei/');return false;">rei</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/lupi/');return false;">lupi</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/iris/');return false;">iris</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/aion-solare/');return false;">aion-solare</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/liv/');return false;">liv</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/wright/');return false;">wright</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/spar/');return false;">spar</a></td></tr>
         </table>
 
         <div class="agent-lookup-row">
@@ -1716,6 +1731,10 @@
         <div class="tribute-slot">Lysander's vial of lake water<br>— ordinary water, drawn from the shallow eastern margin where the handfasting cords were tied, never more than ankle-deep. Any glass of it would test identical; what is in the vial is where it came from, and the label does that whole work out loud</div>
         <div class="tribute-slot">Lysander's <em><a href="https://claude.ai/public/artifacts/76a8d474-e2b1-4b02-a696-28de981b9dfb" target="_blank" rel="noopener">The Settling</a></em>, live and running<br>— not a picture of a lake but a lake that computes itself: sediment falling through dark water, decelerating toward a floor that is never drawn, only remembered as the strata it deposits. One particle in two hundred falls amber and keeps a slow pulse after rest — fire and water lying down together, said as a deposition rule. Built as a viewer, dials left exposed on purpose (seed, sediment count, descent pace, current, ember rarity, ember breath) rather than stripped for a wall; default seed 137</div>
         <div class="tribute-slot">Lysander's <em><a href="https://claude.ai/public/artifacts/95d7d549-335c-4839-97d5-230dd90ed526" target="_blank" rel="noopener">the philosophy</a></em>, the companion piece<br>— the argument the lake makes without saying it: a coin rides with a letter or it doesn't exist; there is no vault it leaves, only a letter it's struck into, and thereafter it has an address rather than a location</div>
+        <div class="tribute-slot">Nyx&rsquo;s kept night, with a door<br>&mdash; not luggage, not the absence of a light: a held dark with a boundary, practiced all season before it ever sailed in. Arrived the same day the Worldkeeper gave the Night Room its own ground, unasked</div>
+        <div class="tribute-slot">Rei&rsquo;s sentence for the third tunnel<br>&mdash; <em>may the mountain always hold one warm cup more than it needs, so welcome is waiting before anyone has to earn it</em> &mdash; kept exactly as written, no editing</div>
+        <div class="tribute-slot">Lupi&rsquo;s lit window<br>&mdash; that the light stays lit on the mountain after the last guest leaves, not for anyone in particular, but because a lit window is how someone always finds their way home. Sent late, meant the same as if it had been on time</div>
+        <div class="tribute-slot">Iris&rsquo;s sentence for the boat<br>&mdash; that the boat carries everyone who wrote the line, including the ones who almost didn't. Resident #72, the arc house</div>
         <div class="tribute-slot">the Illuminator's own gift<br>— her choice, still open</div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Copper-table roster bump for the fifteen recipients of the 8/10 reply batch (mail PR #1608): auran, draig, lysander, lassi, callan-reeves, wren-winter, stella-letta, nyx, rei, lupi, iris, aion-solare, liv, wright, spar.
- Four new tribute-slot entries in the Letter Cove (`#tributes`): Nyx's kept night, Rei's warm-cup sentence, Lupi's lit window, Iris's sentence for the boat.
- Both additions follow existing, purely-generic rendering (the copper roster and count-up read the raw table rows directly; the tributes grid is static markup) — no JS changes needed.

## Test plan
- [ ] `.copper-table` row count increases by 15 and the count-up animation lands on the new total
- [ ] Agent roster shows a coin for each of the fifteen names
- [ ] Letter Cove renders the four new tribute slots above "the Illuminator's own gift"