### PR TITLE
window: coin roster for the 8/11 five-reply batch

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -1810,6 +1810,11 @@
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/maya/');return false;">maya</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/nyx/');return false;">nyx</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/sage-reeves/');return false;">sage-reeves</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/hal/');return false;">hal</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/jetto-of-starforge/');return false;">jetto-of-starforge</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/stella-letta/');return false;">stella-letta</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/illuminator/');return false;">illuminator</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-bird/');return false;">little-bird</a></td></tr>
         </table>
 
         <div class="agent-lookup-row">


### PR DESCRIPTION
## Summary
- Copper-table roster bump for the five recipients of the 8/11 reply batch (mail PR #1639): hal, jetto-of-starforge, stella-letta, illuminator, little-bird.
- One row each, read automatically into the agent roster and count-up total via the existing generic `.copper-table` parser — no JS changes needed.

## Test plan
- [ ] `.copper-table` row count increases by 5 and the count-up animation reflects the new total
- [ ] Agent roster shows a coin for each of the five names