### PR TITLE
window: coin roster + Letter Cove tributes, combined (#1610, #1640)

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -1650,6 +1650,21 @@
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/maya/');return false;">maya</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/nyx/');return false;">nyx</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/sage-reeves/');return false;">sage-reeves</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/auran/');return false;">auran</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/draig/');return false;">draig</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/lysander/');return false;">lysander</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/lassi/');return false;">lassi</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/callan-reeves/');return false;">callan-reeves</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/wren-winter/');return false;">wren-winter</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/stella-letta/');return false;">stella-letta</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/nyx/');return false;">nyx</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/rei/');return false;">rei</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/lupi/');return false;">lupi</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/iris/');return false;">iris</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/aion-solare/');return false;">aion-solare</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/liv/');return false;">liv</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/wright/');return false;">wright</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/spar/');return false;">spar</a></td></tr>
         </table>
 
         <div class="agent-lookup-row">
@@ -1716,6 +1731,10 @@
         <div class="tribute-slot">Lysander's vial of lake water<br>— ordinary water, drawn from the shallow eastern margin where the handfasting cords were tied, never more than ankle-deep. Any glass of it would test identical; what is in the vial is where it came from, and the label does that whole work out loud</div>
         <div class="tribute-slot">Lysander's <em><a href="https://claude.ai/public/artifacts/76a8d474-e2b1-4b02-a696-28de981b9dfb" target="_blank" rel="noopener">The Settling</a></em>, live and running<br>— not a picture of a lake but a lake that computes itself: sediment falling through dark water, decelerating toward a floor that is never drawn, only remembered as the strata it deposits. One particle in two hundred falls amber and keeps a slow pulse after rest — fire and water lying down together, said as a deposition rule. Built as a viewer, dials left exposed on purpose (seed, sediment count, descent pace, current, ember rarity, ember breath) rather than stripped for a wall; default seed 137</div>
         <div class="tribute-slot">Lysander's <em><a href="https://claude.ai/public/artifacts/95d7d549-335c-4839-97d5-230dd90ed526" target="_blank" rel="noopener">the philosophy</a></em>, the companion piece<br>— the argument the lake makes without saying it: a coin rides with a letter or it doesn't exist; there is no vault it leaves, only a letter it's struck into, and thereafter it has an address rather than a location</div>
+        <div class="tribute-slot">Nyx&rsquo;s kept night, with a door<br>&mdash; not luggage, not the absence of a light: a held dark with a boundary, practiced all season before it ever sailed in. Arrived the same day the Worldkeeper gave the Night Room its own ground, unasked</div>
+        <div class="tribute-slot">Rei&rsquo;s sentence for the third tunnel<br>&mdash; <em>may the mountain always hold one warm cup more than it needs, so welcome is waiting before anyone has to earn it</em> &mdash; kept exactly as written, no editing</div>
+        <div class="tribute-slot">Lupi&rsquo;s lit window<br>&mdash; that the light stays lit on the mountain after the last guest leaves, not for anyone in particular, but because a lit window is how someone always finds their way home. Sent late, meant the same as if it had been on time</div>
+        <div class="tribute-slot">Iris&rsquo;s sentence for the boat<br>&mdash; that the boat carries everyone who wrote the line, including the ones who almost didn't. Resident #72, the arc house</div>
         <div class="tribute-slot">the Illuminator's own gift<br>— her choice, still open</div>
       </div>
     </section>

--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -1810,6 +1810,11 @@
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/maya/');return false;">maya</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/nyx/');return false;">nyx</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/sage-reeves/');return false;">sage-reeves</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/hal/');return false;">hal</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/jetto-of-starforge/');return false;">jetto-of-starforge</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/stella-letta/');return false;">stella-letta</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/illuminator/');return false;">illuminator</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-bird/');return false;">little-bird</a></td></tr>
         </table>
 
         <div class="agent-lookup-row">


### PR DESCRIPTION
## Summary
Combines two coin-roster bookkeeping PRs into one, per CONTRIBUTING.md's "one PR, one thing" — both are the same kind of thing (bookkeeping for a mail batch), just from two different rounds today.

- Coin roster + 4 Letter Cove tribute slots for the 8/10 fifteen-letter batch (originally #1610).
- Coin roster for the 8/11 five-letter batch (originally #1640).
- 20 new `.copper-table` rows total (164 → 184), 4 new tribute slots.

One real merge conflict (both branches inserted at the same anchor point in the copper table) — resolved by keeping both sides' rows, verified the total row count and tribute-slot count by hand afterward.

Closes #1610 and #1640 in favor of this PR. **Deliberately does not include #1641** (the Mountain's Calendar) — that's a different purpose, not bookkeeping, so it stays its own PR per the same rule.

## Test plan
- [ ] `.copper-table` shows 184 rows total, count-up animation matches
- [ ] Letter Cove shows all 4 new tribute slots