### PR TITLE
window: the Tomot family tree

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -1044,8 +1044,13 @@
     backface-visibility: hidden; -webkit-backface-visibility: hidden;
   }
   .family-flip-face.family-flip-back { transform: rotateY(180deg); }
-  .racli-flip-link, .roitu-flip-link { cursor: pointer; text-decoration: underline; }
-  .racli-flip-link:hover, .roitu-flip-link:hover { fill: #8a3b2e; }
+  .racli-flip-link, .roitu-flip-link, .tomot-flip-link { cursor: pointer; text-decoration: underline; }
+  .racli-flip-link:hover, .roitu-flip-link:hover, .tomot-flip-link:hover { fill: #8a3b2e; }
+  /* a branch tree pointing back OUT to the Raclados front face, not to
+     another branch -- blue, matching the Plaus square's own color, so it
+     reads as a different kind of door than the family-tree flips above. */
+  .tomot-raclados-link { cursor: pointer; text-decoration: underline; }
+  .tomot-raclados-link:hover { fill: #1f4560; }
   /* the map of Plaus opens from a blue square beside the tree's title now,
      rather than from the founder's own name -- a door reads as a door, and
      an underlined name in a genealogy reads as a footnote. */
@@ -2434,7 +2439,7 @@
 <path d="M151,88 L92,88" fill="none" stroke="#b9975c" stroke-width="1.5"/>
 <line x1="151" y1="88" x2="330" y2="88" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
 <text x="335" y="92" font-size="9.5" fill="#6b5316">Tomo (51)</text>
-<text x="335" y="104" font-size="9" fill="#2f6b45" font-style="italic">&#8594; Tomot family</text>
+<text x="335" y="104" font-size="9" fill="#2f6b45" font-style="italic" class="tomot-flip-link" onclick="flipToTomot()" tabindex="0" role="button" aria-label="turn the page to the Tomot family tree">&#8594; Tomot family</text>
 <line x1="151" y1="88" x2="151" y2="122" stroke="#b9975c" stroke-width="1.5"/>
 <line x1="151" y1="122" x2="330" y2="122" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
 <text x="335" y="126" font-size="9.5" fill="#6b5316">Amo (53)</text>
@@ -2562,6 +2567,153 @@
 <text x="335" y="1638" font-size="9.5" fill="#6b5316">Tau (439)</text>
 <text x="335" y="1650" font-size="9" fill="#8a6d1f" font-style="italic">not yet placed</text>
 <text x="230" y="1678" text-anchor="middle" font-size="9" fill="#8a6d1f" font-style="italic">kept faithfully, by my own claw — V.</text>
+</svg>
+              <div class="racli-flip-back-link" onclick="flipToRaclados()">&#8592; back to the Raclados tree</div>
+              </div>
+
+              <div class="family-back-page" id="tomot-back-content" style="display:none">
+                <button type="button" class="family-back-top" onclick="flipToRacli()">&#8592; The Racli Family Tree</button>
+<svg viewBox="0 0 460 1772" font-family="Georgia, serif" class="racli-tree-svg">
+<rect width="460" height="1772" fill="#f4ead0"/>
+<text x="230" y="28" text-anchor="middle" font-size="15" fill="#7a5a26" letter-spacing="1">The Tomot Family Tree</text>
+<g class="plaus-square-button" onclick="openPlausMap()" tabindex="0" role="button" aria-label="open the map of Plaus City">
+  <rect x="386" y="10" width="34" height="34" rx="4" fill="#2f5f8a" stroke="#1f4560" stroke-width="1.5"/>
+  <text x="403" y="31" text-anchor="middle" font-size="9" fill="#eef0f2">Plaus</text>
+</g>
+<text x="230" y="46" text-anchor="middle" font-size="9.5" fill="#8a6d1f" font-style="italic">branched from the Racli line through Tomo Racli, son of Pif &amp; Sauri</text>
+<text x="92" y="66" text-anchor="middle" font-size="11" fill="#4a3a1e">Tomo Racli (51)</text>
+<text x="210" y="66" text-anchor="middle" font-size="11" fill="#4a3a1e">Deidara (50)</text>
+<path d="M92,57 L92,74 L210,74 L210,57" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="74" x2="151" y2="88" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,88 L92,88" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="92" y1="88" x2="92" y2="165" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="174" text-anchor="middle" font-size="11" fill="#4a3a1e">Fin (78)</text>
+<text x="210" y="174" text-anchor="middle" font-size="11" fill="#4a3a1e">Nana (80)</text>
+<path d="M92,165 L92,182 L210,182 L210,165" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="182" x2="151" y2="196" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,196 L92,196" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="196" x2="330" y2="196" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+<text x="335" y="200" font-size="9" fill="#6b5316">Walka (103) &#8212; Brian (100)</text>
+<text x="335" y="212" font-size="9" fill="#2f6b45" font-style="italic">&#8594; Williams family</text>
+<line x1="92" y1="196" x2="92" y2="273" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="282" text-anchor="middle" font-size="11" fill="#4a3a1e">Walki (103)</text>
+<text x="210" y="282" text-anchor="middle" font-size="11" fill="#4a3a1e">Miraya (105)</text>
+<path d="M92,273 L92,290 L210,290 L210,273" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="290" x2="151" y2="304" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,304 L92,304" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="304" x2="330" y2="304" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+<text x="335" y="308" font-size="9" fill="#6b5316">Dos (133) &#8212; Quvi (134)</text>
+<text x="335" y="320" font-size="9" fill="#2f6b45" font-style="italic">&#8594; Dosuv family</text>
+<line x1="92" y1="304" x2="92" y2="381" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="390" text-anchor="middle" font-size="11" fill="#4a3a1e">Uno (127)</text>
+<text x="210" y="390" text-anchor="middle" font-size="11" fill="#4a3a1e">Xaya (124)</text>
+<path d="M92,381 L92,398 L210,398 L210,381" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="398" x2="151" y2="412" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,412 L92,412" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="92" y1="412" x2="92" y2="489" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="498" text-anchor="middle" font-size="11" fill="#4a3a1e">Zaor (160)</text>
+<text x="210" y="498" text-anchor="middle" font-size="11" fill="#4a3a1e">Amre (162)</text>
+<path d="M92,489 L92,506 L210,506 L210,489" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="506" x2="151" y2="520" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,520 L92,520" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="520" x2="330" y2="520" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+<text x="335" y="524" font-size="9" fill="#6b5316">Sona (184) &#8212; Eon (183)</text>
+<text x="335" y="536" font-size="9" fill="#2f6b45" font-style="italic">&#8594; McGregor family</text>
+<line x1="92" y1="520" x2="92" y2="597" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="606" text-anchor="middle" font-size="11" fill="#4a3a1e">Yone (181)</text>
+<text x="210" y="606" text-anchor="middle" font-size="11" fill="#4a3a1e">Gulmira (181)</text>
+<path d="M92,597 L92,614 L210,614 L210,597" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="614" x2="151" y2="628" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,628 L92,628" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="92" y1="628" x2="92" y2="705" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="714" text-anchor="middle" font-size="11" fill="#4a3a1e">Horax (203)</text>
+<text x="210" y="714" text-anchor="middle" font-size="11" fill="#4a3a1e">Kira (207)</text>
+<path d="M92,705 L92,722 L210,722 L210,705" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="722" x2="151" y2="736" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,736 L92,736" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="736" x2="330" y2="736" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+<text x="335" y="740" font-size="9" fill="#6b5316">Eura (230) &#8212; Fonzel (228)</text>
+<text x="335" y="752" font-size="9" fill="#2f6b45" font-style="italic">&#8594; Platium family</text>
+<line x1="92" y1="736" x2="92" y2="813" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="822" text-anchor="middle" font-size="11" fill="#4a3a1e">Efran (234)</text>
+<text x="210" y="822" text-anchor="middle" font-size="11" fill="#4a3a1e">Berta (231)</text>
+<path d="M92,813 L92,830 L210,830 L210,813" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="830" x2="151" y2="844" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,844 L92,844" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<text x="210" y="844" text-anchor="middle" font-size="7.5" fill="#8a6d1f" font-style="italic">Amethyst dragon lineage</text>
+<line x1="151" y1="844" x2="330" y2="844" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+<text x="335" y="848" font-size="9.5" fill="#6b5316">Ifran (255)</text>
+<text x="335" y="860" font-size="9" fill="#2f5f8a" class="tomot-raclados-link" onclick="flipToRaclados()" tabindex="0" role="button" aria-label="see Sana's own line on the Raclados Royal Family Tree">&#8212; Sana Raclados (248)</text>
+<text x="335" y="872" font-size="9" fill="#2f6b45" font-style="italic">&#8594; Ifran family</text>
+<line x1="92" y1="844" x2="92" y2="921" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="930" text-anchor="middle" font-size="11" fill="#4a3a1e">Emilio (254)</text>
+<text x="210" y="930" text-anchor="middle" font-size="11" fill="#4a3a1e">Zara (255)</text>
+<path d="M92,921 L92,938 L210,938 L210,921" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="938" x2="151" y2="952" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,952 L92,952" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="92" y1="952" x2="92" y2="1029" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="1038" text-anchor="middle" font-size="11" fill="#4a3a1e">Vesp (281)</text>
+<text x="210" y="1038" text-anchor="middle" font-size="11" fill="#4a3a1e">Adriana (284)</text>
+<path d="M92,1029 L92,1046 L210,1046 L210,1029" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1046" x2="151" y2="1060" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,1060 L92,1060" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="92" y1="1060" x2="92" y2="1137" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="1146" text-anchor="middle" font-size="11" fill="#4a3a1e">Adrian (306)</text>
+<text x="210" y="1146" text-anchor="middle" font-size="11" fill="#4a3a1e">Mel (306)</text>
+<path d="M92,1137 L92,1154 L210,1154 L210,1137" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1154" x2="151" y2="1168" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,1168 L92,1168" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1168" x2="330" y2="1168" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+<text x="335" y="1172" font-size="9" fill="#6b5316">Adrian (306) &#8212; Jina (336)</text>
+<line x1="151" y1="1168" x2="151" y2="1202" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1202" x2="330" y2="1202" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+<text x="335" y="1206" font-size="9.5" fill="#6b5316">Pam (364)</text>
+<text x="335" y="1218" font-size="9" fill="#2f6b45" font-style="italic">&#8594; Aquarius family</text>
+<line x1="151" y1="1202" x2="151" y2="1236" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1236" x2="330" y2="1236" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+<text x="335" y="1240" font-size="9.5" fill="#6b5316">Ludo (363)</text>
+<text x="335" y="1252" font-size="9" fill="#2f6b45" font-style="italic">&#8594; Ludoan family</text>
+<text x="100" y="1218" font-size="8.5" fill="#8a6d1f" font-style="italic">(Adrian marries a second time)</text>
+<line x1="92" y1="1168" x2="92" y2="1279" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="1288" text-anchor="middle" font-size="11" fill="#4a3a1e">Austin (330)</text>
+<text x="210" y="1288" text-anchor="middle" font-size="11" fill="#4a3a1e">Yuna (336)</text>
+<path d="M92,1279 L92,1296 L210,1296 L210,1279" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1296" x2="151" y2="1310" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,1310 L92,1310" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="92" y1="1310" x2="92" y2="1387" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="1396" text-anchor="middle" font-size="11" fill="#4a3a1e">Peter (370)</text>
+<text x="210" y="1396" text-anchor="middle" font-size="11" fill="#4a3a1e">Sabrina (369)</text>
+<path d="M92,1387 L92,1404 L210,1404 L210,1387" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1404" x2="151" y2="1418" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,1418 L92,1418" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1418" x2="330" y2="1418" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+<text x="335" y="1422" font-size="9.5" fill="#6b5316">Vincent (393)</text>
+<text x="335" y="1434" font-size="9" fill="#2f6b45" font-style="italic">&#8594; Vincento family</text>
+<line x1="151" y1="1418" x2="151" y2="1452" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1452" x2="330" y2="1452" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+<text x="335" y="1456" font-size="9.5" fill="#6b5316">Petunia (398)</text>
+<text x="335" y="1468" font-size="9" fill="#2f6b45" font-style="italic">&#8594; Adjar family</text>
+<line x1="92" y1="1418" x2="92" y2="1495" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="1504" text-anchor="middle" font-size="11" fill="#4a3a1e">Bork (391)</text>
+<text x="210" y="1504" text-anchor="middle" font-size="11" fill="#4a3a1e">Lilith (391)</text>
+<path d="M92,1495 L92,1512 L210,1512 L210,1495" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1512" x2="151" y2="1526" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,1526 L92,1526" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="92" y1="1526" x2="92" y2="1603" stroke="#b9975c" stroke-width="1.5"/>
+<text x="92" y="1612" text-anchor="middle" font-size="11" fill="#4a3a1e">Maurice (426)</text>
+<text x="210" y="1612" text-anchor="middle" font-size="11" fill="#4a3a1e">Georgia Aurelian (422)</text>
+<path d="M92,1603 L92,1620 L210,1620 L210,1603" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1620" x2="151" y2="1634" stroke="#b9975c" stroke-width="1.5"/>
+<path d="M151,1634 L92,1634" fill="none" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1634" x2="330" y2="1634" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+<text x="335" y="1638" font-size="9.5" fill="#6b5316">Mirabella (440)</text>
+<line x1="151" y1="1634" x2="151" y2="1668" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1668" x2="330" y2="1668" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+<text x="335" y="1672" font-size="9.5" fill="#6b5316">Felix (442)</text>
+<line x1="151" y1="1668" x2="151" y2="1702" stroke="#b9975c" stroke-width="1.5"/>
+<line x1="151" y1="1702" x2="330" y2="1702" stroke="#8a6d1f" stroke-width="1" stroke-dasharray="2,3"/>
+<text x="335" y="1706" font-size="9.5" fill="#6b5316">Seimur (448)</text>
+<text x="230" y="1742" text-anchor="middle" font-size="9" fill="#8a6d1f" font-style="italic">the Tomot branch, still growing &#8212; V.</text>
 </svg>
               <div class="racli-flip-back-link" onclick="flipToRaclados()">&#8592; back to the Raclados tree</div>
               </div>
@@ -5867,6 +6019,11 @@ window.PARTY_HALL_HERB_BASE = './decorations/assets/herbarium/'; // the pane mir
         <rect x="266.5" y="430.0" width="27.0" height="20.0" rx="1.2" fill="#b56b8a" stroke="#6b3d55" stroke-width="1.1"/>
         <rect x="266.5" y="430.0" width="27.0" height="5.6" rx="1.2" fill="#d99cb8" opacity="0.85"/>
       </g>
+      <g class="plaus-bldg"><title>Tomot residence</title>
+        <rect x="221.4" y="359.6" width="26.0" height="20.0" rx="1.2" fill="#2a1e10" opacity="0.22"/>
+        <rect x="220.0" y="358.0" width="26.0" height="20.0" rx="1.2" fill="#b56b8a" stroke="#6b3d55" stroke-width="1.1"/>
+        <rect x="220.0" y="358.0" width="26.0" height="5.6" rx="1.2" fill="#d99cb8" opacity="0.85"/>
+      </g>
       <g class="plaus-bldg"><title>Zoo enclosure</title>
         <rect x="277.4" y="217.6" width="32.0" height="22.0" rx="1.2" fill="#2a1e10" opacity="0.22"/>
         <rect x="276.0" y="216.0" width="32.0" height="22.0" rx="1.2" fill="#4a8f5c" stroke="#245030" stroke-width="1.1"/>
@@ -6964,8 +7121,9 @@ function activateGoldSpin(btn) {
 // for and hides the other. Still one card, still one turn of the page.
 function flipToRacli() { flipToBranch("racli"); }
 function flipToRoitu() { flipToBranch("roitu"); }
+function flipToTomot() { flipToBranch("tomot"); }
 function flipToBranch(which) {
-  ["racli", "roitu"].forEach(function (name) {
+  ["racli", "roitu", "tomot"].forEach(function (name) {
     document.getElementById(name + "-back-content").style.display = name === which ? "block" : "none";
   });
   // the face is what scrolls, not the frame, so a tree left half-read would


### PR DESCRIPTION
The Racli tree already had a `→ Tomot family` line under Tomo Racli & Deidara, dead-ending in a label. This gives it its own tree, one level deeper on the shared flip card.

- **`→ Tomot family`** on the Racli tree is a button now, flipping to a third page on the shared back face (Racli, Roitu, Tomot all live there, one visible at a time — same `flipToBranch()` switch as before).
- **Sixteen generations**, Tomo Racli (51) down to Mirabella/Felix/Seimur, same bracket-and-drop geometry as Racli/Roitu throughout. A few real judgment calls where the family isn't a clean single-child chain:
  - Four sibling forks (Fin/Nana, Walki/Miraya, Zaor/Amre, Horax/Kira) send one child down the spine and the other out to marry into a named family — same pattern as Roitu's Unona → Daillai.
  - Adrian's second marriage (to Jina, whose two children both marry out) is three stacked branches off one drop point — the same three-siblings layout the Racli tree already uses for Tolo/Mi/Si off Soro II & Vaala.
  - Ifran's branch links back to the Raclados **front face** instead of drawing a new tree, since Sana Raclados is already a named leaf there (`Sana (248) → Ifran family`). Only "Sana Raclados" is a live link — "Ifran" stays plain text.
- **A Plaus square** on the Tomot page, identical to the Raclados tree's own — reuses `openPlausMap()`/`closePlausMap()` unmodified, since those only ever swap the map page for `#page-pandara` and never touch which flip page is showing underneath.
- **Top back button → Racli, not Raclados** — Tomot branches off Racli, so the immediate way back is one level up. (The bottom link still goes straight to Raclados, unchanged.)
- **A ninth noble house on the Plaus map** — the Tomot residence, set in a real ~160° gap on the west side of the noble-house ring (the existing 8 sit ~27–33° apart everywhere else), clear of every other building, the castle towers, and the city wall.

Verified in-browser: all three back-face pages switch correctly with scroll resetting between them, the Plaus square opens the map and returns to the still-flipped Tomot page, the top button lands on Racli, the Sana Raclados link lands on the Raclados front face with her row visible, the new residence has zero bounding-box overlap with any of the other 8 houses and sits ~20px inside the city wall. The tree's own `getBBox()` matches its viewBox exactly (0,0,460,1772) across 60 text elements, nothing overflowing or overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)