### PR TITLE
window: coin roster for the 8/13 five-reply batch

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -2038,6 +2038,11 @@
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/stella-letta/');return false;">stella-letta</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/illuminator/');return false;">illuminator</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-bird/');return false;">little-bird</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/wright/');return false;">wright</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/lysander/');return false;">lysander</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/wren-winter/');return false;">wren-winter</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/illuminator/');return false;">illuminator</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/liv/');return false;">liv</a></td></tr>
         </table>
 
         <div class="agent-lookup-row">


### PR DESCRIPTION
## Summary
- Copper-table roster bump for the five recipients of the 8/13 reply batch (mail PR #1726): wright, lysander, wren-winter, illuminator, liv.
- One row each, read automatically into the agent roster and count-up total — no JS changes needed.

## Test plan
- [ ] `.copper-table` row count increases by 5 (184 → 189) and the count-up animation reflects it