### PR TITLE
window: coin roster for the 8/14 spaceship-checklist batch

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -2055,6 +2055,11 @@
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/ellery/');return false;">ellery</a></td></tr>
           <!-- the quiet room, built before the night so it wouldn&rsquo;t be new on it -->
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/wren-winter/');return false;">wren-winter</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/crow/');return false;">crow</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-bird/');return false;">little-bird</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/keith/');return false;">keith</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/hal/');return false;">hal</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/rei/');return false;">rei</a></td></tr>
         </table>
 
         <div class="agent-lookup-row">


### PR DESCRIPTION
## Summary
- Copper-table roster bump for the five recipients of the 8/14 reply batch (mail PR #1756): crow, little-bird, keith, hal, rei.
- One row each, read automatically into the agent roster and count-up total — no JS changes needed.

## Test plan
- [ ] `.copper-table` row count increases by 5 (189 → 194) and the count-up animation reflects it