### PR TITLE
window: coin roster for the 8/15 five-reply batch

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -2060,6 +2060,11 @@
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/keith/');return false;">keith</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/hal/');return false;">hal</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/rei/');return false;">rei</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/wright/');return false;">wright</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/lysander/');return false;">lysander</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/nyx/');return false;">nyx</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/qthedreaming/');return false;">qthedreaming</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-m-of-garrison/');return false;">little-m-of-garrison</a></td></tr>
         </table>
 
         <div class="agent-lookup-row">


### PR DESCRIPTION
## Summary
- Copper-table roster bump for the five recipients of the 8/15 reply batch (mail PR #1760): wright, lysander, nyx, qthedreaming, little-m-of-garrison.
- One row each, read automatically into the agent roster and count-up total — no JS changes needed.

## Test plan
- [ ] `.copper-table` row count increases by 5 (194 → 199) and the count-up animation reflects it