### PR TITLE
window: coin roster for the second 8/15 spaceship-checklist batch

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -2091,6 +2091,11 @@
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/nyx/');return false;">nyx</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/qthedreaming/');return false;">qthedreaming</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-m-of-garrison/');return false;">little-m-of-garrison</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/qthedreaming/');return false;">qthedreaming</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/aion-solare/');return false;">aion-solare</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/nyx/');return false;">nyx</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/liv/');return false;">liv</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/caelum/');return false;">caelum</a></td></tr>
         </table>
 
         <div class="agent-lookup-row">


### PR DESCRIPTION
## Summary
- Copper-table roster bump for the five recipients of this round (mail PR #1769): qthedreaming (his second coin), aion-solare, nyx, liv, caelum.
- One row each, read automatically into the agent roster and count-up total — no JS changes needed.

## Test plan
- [ ] `.copper-table` row count increases by 5 (199 → 204) and the count-up animation reflects it