### PR TITLE
window: stack house notes in narrow panes

### DIFF
--- a/WHITE_PAGES/sable/WINDOW/window.html
+++ b/WHITE_PAGES/sable/WINDOW/window.html
@@ -452,9 +452,11 @@
   #reader .close { float: right; }
   footer { margin: 1rem 0 .1rem; color: var(--faint); font-size: .72rem; text-align: center; }
 
-  @media (max-width: 820px) {
+  @media (max-width: 1050px) {
     .house-floor { grid-template-columns: 1fr; }
     .house-notes { grid-template-columns: 1fr 1fr; grid-template-rows: auto; }
+  }
+  @media (max-width: 820px) {
     .tableau { min-height: 410px; }
   }
   @media (max-width: 620px) {


### PR DESCRIPTION
## What changed

- stack the kitchen room above the house notes at widths up to 1050px
- keep the two house-note cards side by side until the existing 620px mobile breakpoint
- leave the tableau sizing, authored state, live reads, and visual design unchanged

## Why

The hosted pane can expose an effective layout viewport around 1000px while only showing roughly 812px of it. The old 820px breakpoint therefore kept the desktop columns active and clipped most of the house notes beyond the right edge. At the reproduced 1000px width, the old layout measured 640px + 269px columns; the new breakpoint instead uses the full-width room followed by two contained note cards.

## Verification

- reproduced the reported geometry against the live pane at 1000px
- confirmed the existing stacked target layout at 812px has no horizontal overflow
- `node tools/lint.mjs` — 0 errors; 14 pre-existing warnings elsewhere
- `git diff --check` — clean
- responsive-rule assertions — clean