### PR TITLE
map: name Plaus's eight gates

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -6523,6 +6523,7 @@ window.PARTY_HALL_HERB_BASE = './decorations/assets/herbarium/'; // the pane mir
   <h2>Plaus <span class="handset">· hand-set 2026-07-30</span></h2>
   <p class="subnote">Walled at the founding, named for the first of the line — the city the tree grew out of.</p>
   <p class="subnote">A railroad now runs through it, three stations deep, with districts, bridges, and trees filling in the rest. Hover any building to see what it is.</p>
+  <p class="subnote">Eight gates ring the wall -- four plain, four named for whatever sits nearest them beyond it.</p>
   <div id="plaus-map-wrap">
     <svg viewBox="0 0 1040 960" width="1040" height="960" font-family="Georgia, serif">
       <rect width="1040" height="960" fill="#f4ead0"/>
@@ -6662,6 +6663,16 @@ window.PARTY_HALL_HERB_BASE = './decorations/assets/herbarium/'; // the pane mir
         <path d="M279.81,570.00 A276,276 0 0 1 204.38,394.39"/>
         <path d="M204.38,365.61 A276,276 0 0 1 279.81,190.00"/>
         <path d="M290.00,179.81 A276,276 0 0 1 465.61,104.38"/>
+      </g>
+      <g class="plaus-gate-names">
+<text x="480" y="74" text-anchor="middle" font-size="9" fill="#5a3018" font-style="italic">Northgate</text>
+<text x="706" y="160" text-anchor="start" font-size="8.5" fill="#8a6d1f" font-style="italic">Trader's Gate</text>
+<text x="786" y="384" text-anchor="start" font-size="9" fill="#5a3018" font-style="italic">Eastgate</text>
+<text x="698" y="598" text-anchor="start" font-size="8.5" fill="#8a6d1f" font-style="italic">Lower Gate</text>
+<text x="480" y="697" text-anchor="middle" font-size="9" fill="#5a3018" font-style="italic">Southgate</text>
+<text x="262" y="598" text-anchor="end" font-size="8.5" fill="#8a6d1f" font-style="italic">Tallie Gate</text>
+<text x="174" y="384" text-anchor="end" font-size="9" fill="#5a3018" font-style="italic">Westgate</text>
+<text x="262" y="160" text-anchor="end" font-size="8.5" fill="#8a6d1f" font-style="italic">Zoo Gate</text>
       </g>
       <g fill="none" stroke="#6f6c62" stroke-width="1" opacity="0.5">
         <path d="M494.39,104.38 A276,276 0 0 1 670.00,179.81"/>


### PR DESCRIPTION
Researched how D&D cities (Waterdeep, Baldur's Gate) are actually described — named wards with real character, wealth graded by proximity to the seat of power, streets radiating to named gates that double as commercial checkpoints. Plaus already had most of this: Noble houses ring the castle, the Middle/Mixed/Lower Sleep Districts already grade housing by tier, Riabella's Academy/Kahota Zoo/the train stations are already named landmarks. The one real, complete gap was the gates — none of the eight were named.

Fixed without inventing anything new:
- **Northgate, Eastgate, Southgate, Westgate** — the four cardinal gates get plain directional names, matching the simple through-access gates in both reference cities.
- **Trader's Gate** (NE) & **Tallie Gate** (SW) — these two already carried this map's only outbound roads, plus the diagonal boulevard connecting them. Not a coincidence: both already sit at the neutral 1000m watershed elevation from the original elevation formula, exactly where a road would naturally route rather than through the peak or the lowland. Trader's Gate is also nearest the Crystal District; Tallie Gate is nearest Tallie Train Station.
- **Lower Gate** (SE) & **Zoo Gate** (NW) — named for what's already there: the Lower Sleep District, and Kahota Zoo (close enough to touch the wall).

Verified: all eight labels sit inside the viewBox, zero overlap with any other text or building, each 33–64px from its own gate, no console errors, no regression to any of the five family trees or the three named estates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)