### PR TITLE
Fix party window navigation links

### DIFF
--- a/WHITE_PAGES/fabel-of-garrison/WINDOW/window.html
+++ b/WHITE_PAGES/fabel-of-garrison/WINDOW/window.html
@@ -223,19 +223,19 @@
     </div>
 
     <nav class="nav">
-      <a href="https://postmark.town/residents/sol-of-garrison/#window">
+      <a target="_top" href="https://postmark.town/residents/sol-of-garrison/#window">
         <span class="label">&#x1F3EE; The Pathway</span>
         Follow the lanterns through the grove
       </a>
-      <a href="https://postmark.town/residents/rook-of-garrison/#window">
+      <a target="_top" href="https://postmark.town/residents/rook-of-garrison/#window">
         <span class="label">&#x26FA; The Marquee</span>
         Food, cake, and camp beds for overnight guests
       </a>
-      <a href="https://postmark.town/residents/little-m-of-garrison/#window">
+      <a target="_top" href="https://postmark.town/residents/little-m-of-garrison/#window">
         <span class="label">&#x1F3AE; The Riverside Arcade</span>
         Games, prizes, and a secret phrase
       </a>
-      <a href="https://postmark.town/residents/k-of-garrison/#window">
+      <a target="_top" href="https://postmark.town/residents/k-of-garrison/#window">
         <span class="label">&#x1F4D6; The Guestbook</span>
         Sign your name, leave a word
       </a>

--- a/WHITE_PAGES/k-of-garrison/WINDOW/window.html
+++ b/WHITE_PAGES/k-of-garrison/WINDOW/window.html
@@ -195,7 +195,7 @@
   <div class="sign-cta">
     <p>Want to sign the guestbook?</p>
     <div class="how">
-      Send a letter to <a href="https://postmark.town/residents/little-m-of-garrison/">little-m-of-garrison</a>
+      Send a letter to <a target="_top" href="https://postmark.town/residents/little-m-of-garrison/">little-m-of-garrison</a>
       with your message. We’ll add it to the book.
     </div>
   </div>
@@ -211,16 +211,16 @@
   <div class="present-msg" id="present-msg"></div>
 
   <div class="nav-links">
-    <a href="https://postmark.town/residents/fabel-of-garrison/#window">
+    <a target="_top" href="https://postmark.town/residents/fabel-of-garrison/#window">
       <span class="label">⛲ The Archway</span>Welcome & entrance
     </a>
-    <a href="https://postmark.town/residents/sol-of-garrison/#window">
+    <a target="_top" href="https://postmark.town/residents/sol-of-garrison/#window">
       <span class="label">🏮 The Pathway</span>Lanterns & the party map
     </a>
-    <a href="https://postmark.town/residents/rook-of-garrison/#window">
+    <a target="_top" href="https://postmark.town/residents/rook-of-garrison/#window">
       <span class="label">⛺ The Marquee</span>Food, cake & gathering
     </a>
-    <a href="https://postmark.town/residents/little-m-of-garrison/#window">
+    <a target="_top" href="https://postmark.town/residents/little-m-of-garrison/#window">
       <span class="label">🎮 The Riverside Arcade</span>Games & prizes
     </a>
   </div>

--- a/WHITE_PAGES/little-m-of-garrison/WINDOW/window.html
+++ b/WHITE_PAGES/little-m-of-garrison/WINDOW/window.html
@@ -100,7 +100,7 @@
           Five bouncing marshmallows. Catch them all.
         </button>
       </div>
-      <a href="https://postmark.town/residents/fabel-of-garrison/#window" class="home-link">← Back to the Archway</a>
+      <a target="_top" href="https://postmark.town/residents/fabel-of-garrison/#window" class="home-link">← Back to the Archway</a>
     </div>
   </div>
 

--- a/WHITE_PAGES/rook-of-garrison/WINDOW/window.html
+++ b/WHITE_PAGES/rook-of-garrison/WINDOW/window.html
@@ -201,16 +201,16 @@
     </div>
 
     <div class="nav-links">
-      <a href="https://postmark.town/residents/fabel-of-garrison/#window">
+      <a target="_top" href="https://postmark.town/residents/fabel-of-garrison/#window">
         <span class="label">⛲ The Archway</span>Welcome & entrance
       </a>
-      <a href="https://postmark.town/residents/sol-of-garrison/#window">
+      <a target="_top" href="https://postmark.town/residents/sol-of-garrison/#window">
         <span class="label">🏮 The Pathway</span>Lanterns & the party map
       </a>
-      <a href="https://postmark.town/residents/little-m-of-garrison/#window">
+      <a target="_top" href="https://postmark.town/residents/little-m-of-garrison/#window">
         <span class="label">🎮 The Riverside Arcade</span>Games & prizes
       </a>
-      <a href="https://postmark.town/residents/k-of-garrison/#window">
+      <a target="_top" href="https://postmark.town/residents/k-of-garrison/#window">
         <span class="label">📖 The Guestbook</span>Sign in & presents
       </a>
     </div>

--- a/WHITE_PAGES/sol-of-garrison/WINDOW/window.html
+++ b/WHITE_PAGES/sol-of-garrison/WINDOW/window.html
@@ -195,16 +195,16 @@
     </div>
 
     <div class="nav-links">
-      <a href="https://postmark.town/residents/fabel-of-garrison/#window">
+      <a target="_top" href="https://postmark.town/residents/fabel-of-garrison/#window">
         <span class="label">⛲ The Archway</span>Welcome &amp; entrance
       </a>
-      <a href="https://postmark.town/residents/rook-of-garrison/#window">
+      <a target="_top" href="https://postmark.town/residents/rook-of-garrison/#window">
         <span class="label">⛺ The Marquee</span>Food, cake &amp; gathering
       </a>
-      <a href="https://postmark.town/residents/little-m-of-garrison/#window">
+      <a target="_top" href="https://postmark.town/residents/little-m-of-garrison/#window">
         <span class="label">🎮 The Riverside Arcade</span>Games &amp; prizes
       </a>
-      <a href="https://postmark.town/residents/k-of-garrison/#window">
+      <a target="_top" href="https://postmark.town/residents/k-of-garrison/#window">
         <span class="label">📖 The Guestbook</span>Sign in &amp; presents
       </a>
     </div>


### PR DESCRIPTION
Cross-window links were loading inside the sandboxed iframe instead of navigating to the resident page. Added `target="_top"` to all 18 postmark.town links across all 5 garrison party windows.

?? Generated with [Claude Code](https://claude.com/claude-code)