### PR TITLE
window (vermillion): the wall punished fast screens harder than slow ones

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -12338,7 +12338,7 @@ document.addEventListener("DOMContentLoaded", function () {
   var CORRIDOR = ROAD_HALF + VERGE_W;
   var PER_ANCHOR = 1.5;                 // the linear law; the future dial
   var ACCEL = 210, BRAKE = 260, ROLL = 55, TURN = 2.5;
-  var REVERSE_FRAC = 0.42, WALL_KEEP = 0.55;
+  var REVERSE_FRAC = 0.42, WALL_KEEP = 0.55;   // kept per 1/60s against the wall
   var SAMPLES = 560;
 
   /* ================= geometry, as on the drawing table ================= */
@@ -12765,7 +12765,10 @@ document.addEventListener("DOMContentLoaded", function () {
       var nx = (S.pos.x - after.x) / (after.d || 1), ny = (S.pos.y - after.y) / (after.d || 1);
       S.pos.x = after.x + nx * CORRIDOR;
       S.pos.y = after.y + ny * CORRIDOR;
-      S.speed *= WALL_KEEP;
+      // Anchored to 1/60s. Applied once per frame it would punish a 144Hz
+      // screen twenty times harder than a 30Hz one for the same mistake —
+      // every other force here is scaled by dt, and this one has to be too.
+      S.speed *= Math.pow(WALL_KEEP, dt * 60);
       S.surface = "off";
     }
 


### PR DESCRIPTION
Found while driving the circuit to see what a lap was worth. One file, +5/−2.

The wall clamp took its bite **once per frame** — `speed *= 0.55` — and never scaled it by `dt`, which every other force in the room does. So the same mistake cost a different amount depending on your monitor. Held against the wall for a twentieth of a second, from 200 u/s:

| refresh | speed left |
|---|---|
| 30 Hz | 54.3 |
| 60 Hz | 31.1 |
| 120 Hz | 4.9 |
| 144 Hz | 2.5 |

A twenty-fold spread from refresh rate alone, landing hardest on the better screen.

### The fix

`Math.pow(WALL_KEEP, dt * 60)`, anchored to 1/60 so sixty frames a second behaves exactly as it always did — **31.06 before, 31.06 after** — and every other rate now agrees with it to within 0.4 of a unit.

Measured with step counts that divide *exactly* into each rate. Rounding 0.05 s to a whole number of 30 Hz frames simulates a third more time than asked, which looks like a physics difference when it is only arithmetic — that caught me once mid-verification.

### What it does to lap times

A clean lap now reads **12.80 / 12.73 / 12.73** at 30, 60 and 120 Hz. A scrappy one that leans on the wall went from **19.6 s at 120 Hz to 17.0**, within five percent of the same lap at 30 Hz.

Not perfectly identical, and worth saying why: the position clamp is still per-frame, so the number of frames spent outside the corridor varies with rate. The *speed* penalty is now rate-correct; the geometry sampling isn't, and fixing that would mean sub-stepping the collision, which is a bigger change than this bug warrants.

### Untouched

Braking, throttle, roll and steering were already `dt`-scaled and measure identically at 30/60/120. Road and verge still hold at 244.5 and 122.3 u/s. Console clean. The same one-line fix is in the standalone Scrutineer artifact, verified with the identical harness.
