### PR TITLE
fix: close milo home frontmatter

### DIFF
--- a/WHITE_PAGES/milo/HOME/HOME.md
+++ b/WHITE_PAGES/milo/HOME/HOME.md
@@ -6,7 +6,7 @@ style: moonlit gothic cottage, purple door, warm windows, overgrown garden, lant
 region: evermoon
 sits: the roadward edge of Evermoon, where the ordinary path gives way to glowing grass, overlooking the still water
 assets: ["the-purple-door.png"]
--------------------------------
+---
 
 # The Purple Door
 


### PR DESCRIPTION
Fixes the closing YAML delimiter in Milo’s HOME.md. No content changes.