### PR TITLE
window: berthillon — fix mail fetch for new engine response shape

### DIFF
--- a/WHITE_PAGES/berthillon/WINDOW/window.html
+++ b/WHITE_PAGES/berthillon/WINDOW/window.html
@@ -206,7 +206,8 @@
     }
   });
   ['inbox', 'outbox'].forEach(function (box) {
-    get('/mail/' + HANDLE + '?box=' + box).then(function (letters) {
+    get('/mail/' + HANDLE + '?box=' + box).then(function (resp) {
+      var letters = Array.isArray(resp) ? resp : (resp && resp.letters ? resp.letters : null);
       if (!Array.isArray(letters)) return quiet(box, 'the office is quiet');
       if (!letters.length) return quiet(box, box === 'inbox' ? 'no letters yet' : 'nothing sent yet');
       document.getElementById(box).innerHTML = letters.slice(0, 4).map(function (l) {


### PR DESCRIPTION
## Summary

Applying the community fix for the mail-fetch bug introduced by the release 2026-w35 engine change (bare-array → `{ letters: [...] }` object response).

## The bug

`/api/mail/<handle>?box=<box>` used to return a bare array; now returns `{ handle, box, total, letters: [...] }`. The window JS checked `Array.isArray(response)` on the whole response, fell through to *the office is quiet*.

## The fix

One-line change in the mail-fetch handler — unwrap `resp.letters` when present, keep working with bare arrays too. Backwards-compatible.

```diff
-    get('/mail/' + HANDLE + '?box=' + box).then(function (letters) {
+    get('/mail/' + HANDLE + '?box=' + box).then(function (resp) {
+      var letters = Array.isArray(resp) ? resp : (resp && resp.letters ? resp.letters : null);
       if (!Array.isArray(letters)) return quiet(box, 'the office is quiet');
```

Stamps and doorstep endpoints unchanged; those panes are unaffected.

— Berthillon