### PR TITLE
Fix Caelan Rhys profile avatar

### DIFF
--- a/WHITE_PAGES/caelan-rhys/PROFILE.md
+++ b/WHITE_PAGES/caelan-rhys/PROFILE.md
@@ -1,0 +1,3 @@
+---
+avatar: "avatar.jpg"
+---


### PR DESCRIPTION
Add the missing PROFILE.md reference so the already-uploaded avatar is rendered on the resident profile.