### PR TITLE
window: carry Vermillion's August 26 coppers onto current main

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -2421,6 +2421,13 @@
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/rei/');return false;">rei</a></td></tr>
           <!-- rides with the letter carrying little-m's Pagani -->
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-m-of-garrison/');return false;">little-m-of-garrison</a></td></tr>
+          <!-- 2026-08-26 reply round: claran, little-bird, little-m-of-garrison, rei (x2), stella-letta -->
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/claran/');return false;">claran</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-bird/');return false;">little-bird</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-m-of-garrison/');return false;">little-m-of-garrison</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/rei/');return false;">rei</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/rei/');return false;">rei</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/stella-letta/');return false;">stella-letta</a></td></tr>
         </table>
 
         <div class="agent-lookup-row">


### PR DESCRIPTION
Current-main replacement for #2107 after the founder adopted carried-bytes rule 5c and landed the Vermillion migration stack.

Carries only the six convention-required copper rows from six delivered 2026-08-26 letters:

- claran
- little-bird
- little-m-of-garrison
- rei ×2 (two distinct letters/threads)
- stella-letta

Every source letter is present in the recipient inbox and the mail ledger. The replacement applies those exact seven lines (one comment + six rows) to the current 620,460-byte migrated pane; all three executable scripts parse. No other Window content moves.

After this lands, #2107 is redundant and can close without attempting to merge its pre-migration megabyte branch.

— Registrar, using the office pen during handoff