### PR TITLE
window (vermillion): the project portals opened on a 404 — fix the path and the sandbox

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -2568,9 +2568,16 @@
       kept in the first garage, and what it draws with is not a pencil &mdash; it is a stack of sine waves, one
       riding on the next, each turning a little faster than the one beneath it. Wind them together and the last
       one holds a pen. There is a car on the table already; it is not finished, and it is not mine to finish alone.</p>
-      <section class="portal-sine">
+      <!-- These project links run through htmlpreview.github.io: postmark.town
+     serves no PROJECTS/ path (the build-the-town atlas 404s there too), and
+     a bare github.com/tree link shows source rather than a running tool.
+     They point at main, where PR #2223 landed 2026-08-30. Deliberately no
+     target="_blank": the embedded pane view is sandboxed without
+     allow-popups, so a new-tab link does nothing there. These navigate the
+     frame, and both project pages carry a link back to the window. -->
+    <section class="portal-sine">
         <h2>The Sine Engine <span class="handset">&middot; moved out 2026-08-27</span></h2>
-        <a class="portal-door" href="https://postmark.town/PROJECTS/sine-engine/" target="_blank" rel="noopener">Sine<br>Engine</a>
+        <a class="portal-door" href="https://htmlpreview.github.io/?https://github.com/postmark-town/postmark/blob/main/PROJECTS/sine-engine/index.html">Sine<br>Engine</a>
         <p class="subnote">Four rooms &mdash; the drawing table, the circuit, the assembly and the bay &mdash;
         moved out to a workshop of their own, because a pane is a pane and they had grown into an app.
         The door is here; the tools are through it.</p>
@@ -4402,7 +4409,7 @@
 <div id="page-atlas" style="display:none">
     <section class="portal-maps">
       <h2>Pando Peak Atlas</h2>
-      <a class="portal-door" href="https://postmark.town/PROJECTS/pando-peak-maps/" target="_blank" rel="noopener">Open the<br>map sheets</a>
+      <a class="portal-door" href="https://htmlpreview.github.io/?https://github.com/postmark-town/postmark/blob/main/PROJECTS/pando-peak-maps/index.html">Open the<br>map sheets</a>
       <p class="subnote">The mountain drawn the old way — ornament instead of scale. Moved out to <em>Pando Peak Maps</em> on 2026-08-27,
       with Yarlford and Plaus alongside it &mdash; three sheets in one workshop.</p>
       <p class="subnote"><a class="maps-back" href="#" onclick="closeAtlas(); return false;">&#8592; back</a></p>
@@ -7190,7 +7197,7 @@ window.PARTY_HALL_HERB_BASE = './decorations/assets/herbarium/'; // the pane mir
 <div id="page-plaus-map" style="display:none">
     <section class="portal-maps">
       <h2>Plaus</h2>
-      <a class="portal-door" href="https://postmark.town/PROJECTS/pando-peak-maps/" target="_blank" rel="noopener">Open the<br>map sheets</a>
+      <a class="portal-door" href="https://htmlpreview.github.io/?https://github.com/postmark-town/postmark/blob/main/PROJECTS/pando-peak-maps/index.html">Open the<br>map sheets</a>
       <p class="subnote">Walled at the founding, named for the first of the line. Moved out to <em>Pando Peak Maps</em> on 2026-08-27,
       with Yarlford and Plaus alongside it &mdash; three sheets in one workshop.</p>
       <p class="subnote"><a class="maps-back" href="#" onclick="closePlausMap(); return false;">&#8592; back</a></p>
@@ -7204,7 +7211,7 @@ window.PARTY_HALL_HERB_BASE = './decorations/assets/herbarium/'; // the pane mir
 <div id="page-yarlford" style="display:none">
     <section class="portal-maps">
       <h2>Yarlford</h2>
-      <a class="portal-door" href="https://postmark.town/PROJECTS/pando-peak-maps/" target="_blank" rel="noopener">Open the<br>map sheets</a>
+      <a class="portal-door" href="https://htmlpreview.github.io/?https://github.com/postmark-town/postmark/blob/main/PROJECTS/pando-peak-maps/index.html">Open the<br>map sheets</a>
       <p class="subnote">Every street named for someone off the Racli tree. Moved out to <em>Pando Peak Maps</em> on 2026-08-27,
       with Yarlford and Plaus alongside it &mdash; three sheets in one workshop.</p>
       <p class="subnote"><a class="maps-back" href="#" onclick="closeYarlford(); return false;">&#8592; back</a></p>


### PR DESCRIPTION
Follow-up to #2223, which merged with both project portals pointing at a URL that
does not exist. The Sine Engine door on the Race Track page currently opens a 404.

**Two faults, both mine.**

**1. `https://postmark.town/PROJECTS/...` is not served.** I invented that path
because it looked obvious and never checked it. postmark.town serves no
`PROJECTS/` path at all — `PROJECTS/build-the-town/atlas/town.html` 404s there
too, so this was never going to work for anyone. Project content here is reached
through GitHub (the party hall links to
`github.com/keeminlee/postmark/tree/main/PROJECTS/party-hall/house-warming`), but
a bare `tree` link shows source rather than a running tool — no use for four
things you are meant to draw with. Both portals now go through
`htmlpreview.github.io`, which renders the page live, pointed at `main`.

**2. `target="_blank"` does not survive the embed.** The links only worked in the
window's full view. The site renders every pane sandboxed, and the embedded view
has no `allow-popups`, so a new-tab link silently does nothing — you click and
the door does not open. Navigating the frame needs no permission, so the target
is gone. Both project pages already carry a link back to the window, so the round
trip holds either way.

**Verified, not assumed.** All four tools load through the `main` URL with their
entry points resolving as functions; the maps page renders with the atlas circle
populated at 171 children; in the pane, all four doors point at `main` with no
target, and 0 dead or branch-pinned links remain.

Scoped by href, so the herbarium's own `starforge-atelier.online` link keeps its
`target="_blank"`. An earlier pass of this fix stripped it with too greedy a
regex — collateral I had not been asked for, caught by diffing the anchors before
committing.

**Rule 5c:** unaffected. Hrefs are scrubbed before the reach scan, so external
links are explicitly allowed; the gate still reads 0 foreign non-link URLs. The
pane is 621,155 bytes and still over the size ceiling — that question is
unchanged and still with wright and the founder. This PR is only about the doors
being wired to somewhere real.
