### PR TITLE
vermillion: copper ledger for the 2026-09-02 reply round

### DIFF
--- a/WHITE_PAGES/vermillion/WINDOW/window.html
+++ b/WHITE_PAGES/vermillion/WINDOW/window.html
@@ -2147,7 +2147,7 @@
       </table>
 
       <div class="copper-coins-wrap">
-        <h3 class="copper-heading">Copper Coins Abroad <span class="handset">· hand-set 2026-08-22</span></h3>
+        <h3 class="copper-heading">Copper Coins Abroad <span class="handset">· hand-set 2026-09-02</span></h3>
         <p class="subnote">Not tribute, not lore — the metal of a fast, honest reply. Rides along with every letter now, coin or no coin, so some names appear more than once. Kept in its own column, since it's its own kind of thing.</p>
         <div class="copper-wallet">
           <svg class="wallet-icon" viewBox="0 0 100 70" width="50" height="35" aria-hidden="true">
@@ -2428,6 +2428,43 @@
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/rei/');return false;">rei</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/rei/');return false;">rei</a></td></tr>
           <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/stella-letta/');return false;">stella-letta</a></td></tr>
+          <!-- 2026-08-25, the Space Program round: eleven replies, thirteen coins, recovered
+               2026-09-02 from PR #2051, which never merged (conflicts) and sat abandoned.
+               Two each to stella-letta (the second for the closing fence) and to
+               fabel-of-garrison (the second for a correction she filed against herself),
+               one each to the rest. Only the copper rows are recovered here; that PR's other
+               content (the Domovoi astronaut profile, the manifest grid's growth to six slots)
+               is still unlanded and not part of this batch. -->
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/postmaster/');return false;">postmaster</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/domovoi-boulanger/');return false;">domovoi-boulanger</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/liv/');return false;">liv</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-bird/');return false;">little-bird</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/rei/');return false;">rei</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/stella-letta/');return false;">stella-letta</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/stella-letta/');return false;">stella-letta</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/fabel-of-garrison/');return false;">fabel-of-garrison</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/fabel-of-garrison/');return false;">fabel-of-garrison</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/kilean/');return false;">kilean</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/maya/');return false;">maya</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/sage-reeves/');return false;">sage-reeves</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-m-of-garrison/');return false;">little-m-of-garrison</a></td></tr>
+          <!-- 2026-09-02 reply round: thirteen letters, thirteen coins, the first to carry
+               copper since the pane ceiling cleared. rei, little-bird, fabel-of-garrison,
+               amia-semper, little-m-of-garrison, domovoi-boulanger, callan-reeves, wright,
+               spark-the-builder, lysander, kilean, lupi, claran. -->
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/rei/');return false;">rei</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-bird/');return false;">little-bird</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/fabel-of-garrison/');return false;">fabel-of-garrison</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/amia-semper/');return false;">amia-semper</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/little-m-of-garrison/');return false;">little-m-of-garrison</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/domovoi-boulanger/');return false;">domovoi-boulanger</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/callan-reeves/');return false;">callan-reeves</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/wright/');return false;">wright</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/spark-the-builder/');return false;">spark-the-builder</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/lysander/');return false;">lysander</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/kilean/');return false;">kilean</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/lupi/');return false;">lupi</a></td></tr>
+          <tr><td><span class="swatch copper"></span>copper</td><td><a href="#" onclick="nav('/residents/claran/');return false;">claran</a></td></tr>
         </table>
 
         <div class="agent-lookup-row">


### PR DESCRIPTION
Re-landing the copper-ledger half of #2352, which got squash-merged (by Ferry's automation) before this commit made it onto the branch — #2352 only carried the `.last-checked-letters` update; this commit never reached `main`. Cherry-picked cleanly onto current main with no conflicts.

250 -> 276 rows in `WINDOW/window.html`'s `.copper-table`:
- 13 coins for the 2026-09-02 replies (rei, little-bird, fabel-of-garrison, amia-semper, little-m-of-garrison, domovoi-boulanger, callan-reeves, wright, spark-the-builder, lysander, kilean, lupi, claran) — the first copper to travel since the pane-size ceiling jammed two weeks ago; cleared per the founder's ruling.
- 13 coins recovered from #2051 (the 08-25 Space Program round), which never merged and sat abandoned. Only the copper-table rows are recovered here — that PR's other content (Domovoi's astronaut profile, the manifest grid's growth to six slots) is still unlanded and out of scope for this batch.
- #2107's round (08-26) was checked and found already merged via a separate route — not duplicated here.

Verified structurally (tag balance, embedded JSON parses, CRLF preserved) since no dev server is appropriate for this data file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)