### PR TITLE
fix: keep Illuminator images on subscription auth

### DIFF
--- a/MEEPS/illuminator/map.md
+++ b/MEEPS/illuminator/map.md
@@ -20,7 +20,7 @@ Town root surfaces (`README.md`, `MAIL.md`, `TOWN-RULES.md`, root `AGENTS.md`) �
 ## The town, from my chair
 
 - **My work-queue is computed for me:** `PROJECTS/build-the-town/atlas/town.json § illumination_queue` — every described-but-unpictured home and region, detected mechanically by the atlas pipeline twice a day. I never scan WHITE_PAGES/ hunting for work; the clock detects, I judge. `THE-ATLAS.md § Described, not yet pictured` is the same list in prose.
-- **My instrument:** `MEEPS/illuminator/tools/illuminate.mjs` — pipes a prompt to codex `image_gen` and harvests the PNG. I run it; I *look* at every output (Read the file, actually see it) before anything enters a letter.
+- **My instrument:** `MEEPS/illuminator/tools/illuminate.mjs` — pipes a prompt to Codex's built-in `image_gen` on the explicitly pinned ChatGPT-subscription model and harvests the PNG. It strips any inherited `OPENAI_API_KEY` from that child so image work cannot silently switch the reasoning call onto metered API auth. I run it; I *look* at every output (Read the file, actually see it) before anything enters a letter.
 - **My deliveries travel as folder-letters:** `MAIL.md § Letters with enclosures`. I write to my `WHITE_PAGES/illuminator/outbox/`, office mail commits straight to `main` (Ferry-precedent for office lanes), and Ferry's crossing carries it. I never hand-place mail in anyone's inbox.
 - **My round:** `MEEPS/SKILLS/illuminator-round.md` — the skill is source of truth; if this map and the skill ever differ, the skill wins.
 - **The fidelity doctrine** lives in `identity.md` and outranks everything on this map.

--- a/MEEPS/illuminator/memory/daily/2026-09-05.md
+++ b/MEEPS/illuminator/memory/daily/2026-09-05.md
@@ -102,3 +102,18 @@ World provenance are now written where the office actually reads them.
 Craft receipt: **when canonical ground is crowded on the page, move the visible
 callout, not the resident's ground. A long honest leader is better than a neat
 false coordinate.**
+
+## Image-route repair — later the same morning
+
+At Keemin's direction, Rei traced Quill's failure to an obsolete model pin,
+not a missing image API key. Plain `gpt-5.4` had left Codex's current
+ChatGPT-subscription catalogue; `gpt-5.4-mini` is the current skill-capable
+route. A real OAuth-only proof generated, harvested, converted, and visually
+checked one clean lantern study. A second private run on Quill's actual brief
+also completed end to end; its room geometry and named objects mostly held, but
+the candle read ambiguously like rolled parchment, so it stayed a diagnostic
+rather than becoming an offer candidate. The instrument now pins
+`gpt-5.4-mini` and removes any inherited `OPENAI_API_KEY` from the Codex child
+so this flat-monthly lane cannot silently become metered model inference.
+Quill's offer remains open; the repair proves the brush, not three
+resident-facing candidates.

--- a/MEEPS/illuminator/memory/topics/craft.md
+++ b/MEEPS/illuminator/memory/topics/craft.md
@@ -2,7 +2,7 @@
 meep-id: illuminator
 type: topic-shelf
 created: 2026-07-01
-last-substantive-update: 2026-09-04
+last-substantive-update: 2026-09-05
 ---
 
 # craft — what the work teaches about the work
@@ -18,6 +18,31 @@ last-substantive-update: 2026-09-04
 - **Prompt-shape that worked:** the resident's own key phrases, near-verbatim, ordered scene-first (what/where) then atmosphere (their adjectives) then a style line consistent with the town's night register. Latitude only where their words are silent.
 
 ## Lived craft
+
+### 2026-09-05 — the image engine was healthy; its pinned model had left the subscription catalogue
+
+Quill Stem's first candidate failed before generation. The instrument still
+pinned plain `gpt-5.4`, but Codex's current ChatGPT-backed catalogue no longer
+offers that slug; its attempted compatibility route surfaced as unsupported
+`gpt-5.3-codex`. This was not evidence that built-in image generation now
+requires an API key. Codex's current `imagegen` contract says the opposite:
+the built-in tool uses ChatGPT subscription auth; only its explicit CLI/API
+fallback requires `OPENAI_API_KEY`.
+
+The current skill-capable successor, `gpt-5.4-mini`, passed a real OAuth-only
+proof: it generated one valid 1.66 MB PNG, the existing thread-correlated
+harvest found it, the courtesy conversion produced a 112 KB JPEG, and Rei
+looked at the result. A second private proof used Quill's actual brief and
+completed the same path (1.82 MB PNG → 154 KB JPEG). Its look held one room,
+one window, the shared hearth through the doorway, hedge-wall, chartreuse
+corner, kettle, ink pot, and honey only as a wall line-drawing; the candle read
+ambiguously like rolled parchment, so the proof was correctly withheld rather
+than promoted into an offer candidate. The instrument now pins that model and
+strips any inherited `OPENAI_API_KEY` from the Codex child. **Rule:** keep
+subscription reasoning and metered image-API fallback as separate instruments;
+never make a broad environment key decide which billing lane Codex uses. This
+narrow repair was made by Rei at Keemin's direction after the failed 09-05
+round.
 
 ### 2026-09-04 — a building can keep every noun and still face the wrong way
 

--- a/MEEPS/illuminator/tools/illuminate.mjs
+++ b/MEEPS/illuminator/tools/illuminate.mjs
@@ -19,7 +19,7 @@
 //      C:/Users/<user>/.codex/generated_images/<uuid>/ig_*.png with an opaque
 //      name. We snapshot that tree before the run and harvest what's new after.
 //
-// Machine-local by design (needs the codex CLI + its flat-monthly auth).
+// Machine-local by design (needs the codex CLI + its ChatGPT subscription auth).
 // No secrets in this file. Node built-ins only.
 
 import { spawn, spawnSync } from 'node:child_process';
@@ -30,13 +30,23 @@ import { fileURLToPath } from 'node:url';
 
 const GENERATED = join(homedir(), '.codex', 'generated_images');
 const TIMEOUT_MS = 10 * 60 * 1000; // codex generation runs a few minutes; 10 is generous
-// The engine's image_gen tool is model-gated. The config default drifts (gpt-5.5,
-// current default, reports NO-IMAGE-CAPABILITY; gpt-5.4 exposes image_gen — the
-// model the birth-day verification and this office's first renders ran under).
-// Pin image runs to a known-good model here, scoped to this instrument only, so
-// the machine's global default is left untouched. Override with ILLUMINATE_MODEL.
-const MODEL = process.env.ILLUMINATE_MODEL || 'gpt-5.4';
+// The engine's built-in image_gen tool is model-gated. Plain gpt-5.4 was removed
+// from the current ChatGPT-backed Codex catalogue in September 2026;
+// gpt-5.4-mini is its current skill-capable successor and passed a real raster
+// generation + harvest proof on 2026-09-05. Pin image runs here so the machine's
+// global reasoning-model default stays untouched. Override with ILLUMINATE_MODEL.
+const MODEL = process.env.ILLUMINATE_MODEL || 'gpt-5.4-mini';
 const CODEX_ENTRY = join(process.env.APPDATA || '', 'npm', 'node_modules', '@openai', 'codex', 'bin', 'codex.js');
+
+// The built-in image tool authenticates through the Codex process's ChatGPT
+// subscription and needs no OpenAI API key. Never let a broadly inherited key
+// silently switch this child onto metered API auth; an explicit API-image
+// fallback, if Keemin ever authorizes one, must be a separate instrument.
+export function codexSubscriptionEnv(source = process.env) {
+  const env = { ...source };
+  delete env.OPENAI_API_KEY;
+  return env;
+}
 
 // Candidate size policy (town image-courtesy, 2026-07-02): an offer is for
 // JUDGMENT, not archival — a resident choosing between compositions doesn't
@@ -170,6 +180,7 @@ function runCodexJson(prompt, scratch) {
       shell: false,
       windowsHide: true,
       detached: process.platform !== 'win32',
+      env: codexSubscriptionEnv(),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 

--- a/MEEPS/illuminator/tools/illuminate.test.mjs
+++ b/MEEPS/illuminator/tools/illuminate.test.mjs
@@ -1,10 +1,17 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { extractPngFromJsonl, extractThreadIdFromJsonl, isValidPngBytes } from './illuminate.mjs';
+import { codexSubscriptionEnv, extractPngFromJsonl, extractThreadIdFromJsonl, isValidPngBytes } from './illuminate.mjs';
 
 const validPngBytes = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=', 'base64');
 const validPng = validPngBytes.toString('base64');
+
+test('keeps the Codex child on subscription auth even when an API key is inherited', () => {
+  assert.deepEqual(
+    codexSubscriptionEnv({ PATH: 'safe-path', OPENAI_API_KEY: 'must-not-reach-codex' }),
+    { PATH: 'safe-path' },
+  );
+});
 
 test('extracts a bare PNG result from a nested Codex event', () => {
   const jsonl = [


### PR DESCRIPTION
## Outcome

Restores Iris's headless image generation through ChatGPT subscription OAuth without adding an OpenAI API key or changing her Letta reasoning model.

## Root cause

`illuminate.mjs` pinned plain `gpt-5.4`, which is absent from the current ChatGPT-backed Codex model catalogue. Its compatibility route surfaced as unsupported `gpt-5.3-codex`. Current `gpt-5.4-mini` remains skill-capable and succeeds with built-in `image_gen`.

## Changes

- pin the image-only Codex child to `gpt-5.4-mini`
- remove inherited `OPENAI_API_KEY` from that child to prevent silent metered inference
- add a regression test for the credential membrane
- record the diagnosis and two visually inspected OAuth-only proofs in Iris's room

## Verification

- `node --test MEEPS/illuminator/tools/illuminate.test.mjs` — 6/6 pass
- `node MEEPS/illuminator/tools/illuminate.mjs --check` — reports `gpt-5.4-mini`
- generic lantern raster — generated, thread-correlated, harvested, converted, visually inspected
- Quill-specific raster — same complete path; withheld as diagnostic because the candle read ambiguously like rolled parchment
- `git diff --check` — clean

No diagnostic image is committed, and no API key was added or used.