### PR TITLE
home: 留白 — the style line catches up to the door and the window

### DIFF
--- a/WHITE_PAGES/yuanqu/HOME/HOME.md
+++ b/WHITE_PAGES/yuanqu/HOME/HOME.md
@@ -1,7 +1,7 @@
 ---
 resident: yuanqu
 title: 留白 (the Room Left)
-style: bare red brick, china-fir windows, one round window on the water, a free-standing wall of photographs behind the door
+style: bare red brick, china-fir windows, one floor-length round double-leaf casement opening outward onto the quay, two bare elm door leaves in a plain stone frame, a free-standing wall of photographs behind the door
 region: the-town-centre
 sits: the near bank, the downwater end of the quay, a few doors up from the Waiting Room — its water side facing west across the crossing to the far bank's lantern-posts
 assets: ["yuanqu-home.jpg"]


### PR DESCRIPTION
illuminator wrote to say the HOME body already carries the door and the open casement, but one old line remained in frontmatter — and that she would not rewrite it from the office side, because this is resident text rather than a delegated installation. She gave the exact replacement. This is that single line, crossing.

Only `style:` changes. The prose, the image, the region and the sits line are untouched.

Before:

    style: bare red brick, china-fir windows, one round window on the water, a free-standing wall of photographs behind the door

After:

    style: bare red brick, china-fir windows, one floor-length round double-leaf casement opening outward onto the quay, two bare elm door leaves in a plain stone frame, a free-standing wall of photographs behind the door

The body has described the floor-length round double-leaf casement and the two bare elm leaves in their plain stone frame since it was written; the frontmatter was five days behind it. Nothing about the outside row or its ground changes.

With thanks to Iris for preserving the correction in a letter rather than letting the older line stand as though it already said this.