### PR TITLE
window: 留白 — 22px all the way round, not just the top

### DIFF
--- a/WHITE_PAGES/yuanqu/WINDOW/window.html
+++ b/WHITE_PAGES/yuanqu/WINDOW/window.html
@@ -85,11 +85,13 @@
   /* 门里那一眼：影壁。整页唯一一张图，所以给它整幅宽度，别的照旧空着。
      图就放在 window.html 旁边，写相对路径——同源，不算往外抓。
      取不回来就整块收起来（onerror），不留破图标。 */
-  /* 左右贴边：这块不在 .wrap 里，是 body 的直接孩子——body 的 margin 是 0，
-     所以 width:100% 天然顶到框的两边，不用拿 100vw 去猜视口有多宽。
-     上面不贴：留 22px。照片怼死在框沿上时，镇子那圈 1px 描边和 8px 圆角
-     正好压在照片边上；松开一格就不打架了。左右照旧顶满，那是特意要的。 */
-  .doorview{margin:22px 0 34px; width:100%; border:0; border-radius:0;
+  /* 四边都不贴：22px 一圈。原来是顶死的，可镇子把这块套在
+       .win-frame{border:1px solid; border-radius:8px}
+     里面，描边和圆角就压在照片边上，角还把画面切掉一块。让开一圈，
+     那条边线自己有背景可坐，照片也就完整了。
+     这块仍旧是 body 的直接孩子、不进 .wrap——留的是一圈空，不是去跟
+     正文那一栏对齐。所以拿掉 width:100%，让 margin 自己把宽度收出来。 */
+  .doorview{margin:22px; border:0; border-radius:0;
     overflow:hidden; line-height:0; background:var(--glass)}
   .doorview img{display:block; width:100%; height:auto}
 


### PR DESCRIPTION
#2603 gave the doorview image a 22px margin at the top and left the sides flush. It should be a margin on all four sides; that change was pushed to the branch after the PR had already merged, so it never travelled. This is it.

The reason is the frame. Embedded on the resident page the pane sits in

    .win-frame{border:1px solid var(--pm-line,#333); border-radius:8px}

and with the image hard against the left and right edges, that hairline and its corners land on the photograph rather than beside it. A margin all the way round gives the border its own background to sit on.

It stays a direct child of `body` rather than moving into `.wrap`: what it gets is a margin, not alignment with the text column. So `width:100%` comes off and the margin sets the width.

    .doorview{margin:22px 0 34px; width:100%}   ->   .doorview{margin:22px}

Measured in a headless render of the built page: 22px top, 22px left, 22px right.

Only `WHITE_PAGES/yuanqu/WINDOW/window.html`.