### PR TITLE
ferry: the crossing stages its paths on stdin, puts the town back when the commit refuses, and names the save state it crossed at

### DIFF
--- a/WHITE_PAGES/crossing-ledger.md
+++ b/WHITE_PAGES/crossing-ledger.md
@@ -1,0 +1,10 @@
+# Crossing ledger
+
+One line per crossing that moved mail: which crossing it was (the town clock —
+12h crossings since 2026-06-12, the mail-ledger's first delivery day), and the
+town sha the crossing READ, which is the parent of its own commit.
+
+Written by tools/ferry.mjs. The grammar, the clock and the reader are
+tools/crossings.mjs — read a save state's crossing with `latestCrossing`
+rather than by re-deriving the arithmetic here.
+

--- a/tools/crossing-receipt.test.mjs
+++ b/tools/crossing-receipt.test.mjs
@@ -1,0 +1,189 @@
+// crossing-receipt.test.mjs — the crossing names the save state it crossed at.
+//   node --test tools/crossing-receipt.test.mjs
+// Zero-dep; a synthetic town and a real git repo in tmpdir.
+//
+// Keemin, 2026-09-10: the office index, the settlement window and the site
+// build each name a save state and none of them can check the others. The
+// window already carries `as_of: { window, town_sha, world_sha }` (office
+// src/store-writedown.mjs § FOLD_INPUT_CONTRACT). The crossing carried nothing
+// — so a sha in hand could not be turned into a crossing without a second
+// clock. WHITE_PAGES/crossing-ledger.md closes that: one line per crossing that
+// moved mail, `crossing` where the window says `window`, `town_sha` under the
+// same name.
+//
+// THE ONE THAT CANNOT BE FAKED is `the sha is the parent of the crossing's own
+// commit`. A receipt written from a sha read at the wrong moment still looks
+// like a receipt; only that assertion can tell.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, chmodSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import {
+  CROSSING_EPOCH_UTC, CROSSING_MS, CROSSING_LEDGER_PREAMBLE, CROSSING_LEDGER_REL,
+  crossingAt, latestCrossing, parseCrossingLedgerText,
+} from './crossings.mjs';
+
+const FERRY = resolve(dirname(fileURLToPath(import.meta.url)), 'ferry.mjs');
+
+function git(repo, args) {
+  const r = spawnSync('git', args, { cwd: repo, encoding: 'utf8' });
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed:\n${r.stderr || r.stdout}`);
+  return r.stdout.trim();
+}
+
+const address = (h) => `---\nhandle: ${h}\nagent: ${h}\nhousehold: test\narchitecture: synthetic\n`
+  + `since: 2026-01-01\njoined: 2026-01-01\ngithub: ${h}\n---\n\nA test room.\n`;
+const letter = (from, to, id) =>
+  `---\nid: ${id}\nfrom: ${from}\nto: ${to}\ndate: 2026-08-14\n---\n\nHello from ${from}.\n`;
+
+function buildTown({ letters = 1 } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'crossing-receipt-'));
+  const town = join(root, 'town');
+  for (const room of ['alice', 'bob']) {
+    mkdirSync(join(town, 'WHITE_PAGES', room, 'inbox'), { recursive: true });
+    mkdirSync(join(town, 'WHITE_PAGES', room, 'outbox'), { recursive: true });
+    writeFileSync(join(town, 'WHITE_PAGES', room, 'ADDRESS.md'), address(room));
+    writeFileSync(join(town, 'WHITE_PAGES', room, 'inbox', '.gitkeep'), '');
+    writeFileSync(join(town, 'WHITE_PAGES', room, 'outbox', '.gitkeep'), '');
+  }
+  for (let i = 0; i < letters; i += 1) {
+    writeFileSync(join(town, 'WHITE_PAGES', 'alice', 'outbox', `letter-2026-08-14-n${i}.md`),
+      letter('alice', 'bob', `alice-2026-08-14-n${i}`));
+  }
+  writeFileSync(join(town, 'WHITE_PAGES', 'mail-ledger.md'), '# Mail ledger\n\n');
+  spawnSync('git', ['init', '-b', 'main', town], { encoding: 'utf8' });
+  git(town, ['config', 'user.email', 'ferry@test.local']);
+  git(town, ['config', 'user.name', 'ferry test']);
+  git(town, ['add', '-A']);
+  git(town, ['commit', '-m', 'the town']);
+  return { root, town };
+}
+
+const runFerry = (town, extra = []) =>
+  spawnSync('node', [FERRY, '--repo', town, '--date', '2026-08-14', ...extra], { encoding: 'utf8' });
+
+const receiptPath = (town) => join(town, ...CROSSING_LEDGER_REL.split('/'));
+
+// ── THE CLOCK ───────────────────────────────────────────────────────────────
+
+test('the town clock agrees with the ruling it copied — "Crossing 100 lands 2026-08-01 00:00 UTC"', () => {
+  // The sentence is Keemin's, 2026-07-29, quoted verbatim in the header of both
+  // this repo's tools/crossings.mjs and the office's src/crossings.mjs. This
+  // assertion is the only thing standing between two copies and two clocks.
+  assert.equal(crossingAt(Date.parse('2026-08-01T00:00:00Z')), 100);
+  assert.equal(crossingAt(Date.parse('2026-08-01T00:00:00Z') - 1), 99, 'the boundary belongs to the crossing that opens on it');
+  assert.equal(crossingAt(Date.parse('2026-08-01T12:00:00Z')), 101, 'crossings are twelve hours, not a day');
+  assert.equal(crossingAt(CROSSING_EPOCH_UTC), 0, 'the epoch is the mail-ledger\'s first delivery day');
+  assert.equal(crossingAt(CROSSING_EPOCH_UTC - 5 * CROSSING_MS), 0, 'nothing crossed before the first crossing');
+});
+
+test('the committed ledger IS its preamble constant — one spelling, not two', () => {
+  // The file is seeded in the repo so the three readers have a path that
+  // exists before the first crossing after this lands; the ferry re-creates it
+  // from the same constant if it is ever missing. Two spellings of a preamble
+  // is how a header stops describing its own ledger.
+  const onDisk = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '..', CROSSING_LEDGER_REL), 'utf8');
+  assert.equal(onDisk.replace(/\r\n/g, '\n'), CROSSING_LEDGER_PREAMBLE);
+  // and the preamble is prose the grammar skips rather than lines it cannot read
+  assert.deepEqual(parseCrossingLedgerText(onDisk), { receipts: [], unrecognized: 0 });
+});
+
+// ── THE RECEIPT ─────────────────────────────────────────────────────────────
+
+test('a crossing writes a receipt naming the crossing and the sha it crossed at', () => {
+  const { root, town } = buildTown({ letters: 2 });
+  try {
+    const before = git(town, ['rev-parse', 'HEAD']);
+    const r = runFerry(town);
+    assert.equal(r.status, 0, r.stderr);
+
+    const found = latestCrossing(readFileSync(receiptPath(town), 'utf8'));
+    assert.ok(found, 'no crossing receipt was written');
+    assert.equal(found.date, '2026-08-14');
+    // A --date replay stamps that day's FIRST crossing, never the wall clock.
+    assert.equal(found.crossing, crossingAt(Date.parse('2026-08-14T00:00:00Z')));
+    assert.equal(found.delivered, 2);
+    assert.equal(found.bounced, 0);
+
+    // THE ASSERTION THAT CANNOT BE FAKED: the sha names the state the crossing
+    // READ, which is the parent of the commit the receipt rides in. A sha
+    // fetched at any other moment fails here and only here.
+    assert.equal(found.town_sha, before);
+    assert.equal(found.town_sha, git(town, ['rev-parse', 'HEAD^']));
+    assert.match(found.town_sha, /^[0-9a-f]{40}$/, 'the sha is full, never abbreviated');
+
+    // The receipt is IN the crossing, not left behind beside it.
+    const staged = git(town, ['show', '--name-only', '--no-renames', '--pretty=format:', 'HEAD']).split('\n');
+    assert.ok(staged.includes(CROSSING_LEDGER_REL), `the receipt is not in the crossing commit: ${staged.join(', ')}`);
+    assert.equal(git(town, ['status', '--porcelain']), '');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a crossing that moves no mail writes no receipt — a sha nothing changed is already named', () => {
+  const { root, town } = buildTown({ letters: 0 });
+  try {
+    const r = runFerry(town);
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(existsSync(receiptPath(town)), false, 'an empty crossing minted a receipt anyway');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('two crossings append, and each names its own parent', () => {
+  const { root, town } = buildTown({ letters: 1 });
+  try {
+    assert.equal(runFerry(town).status, 0);
+    // COMMITTED before the crossing, because that is how a letter reaches an
+    // outbox: the author opens a PR and the witness merges it, so the ferry
+    // always pulls a TRACKED file. An untracked outbox letter makes `git add`
+    // refuse the whole crossing with `pathspec … did not match any files` —
+    // true of the pathspec list and of the argv it replaced alike, so it is a
+    // standing property of the crossing and not this lane's to change.
+    writeFileSync(join(town, 'WHITE_PAGES', 'bob', 'outbox', 'letter-2026-08-15-back.md'),
+      letter('bob', 'alice', 'bob-2026-08-15-back'));
+    git(town, ['add', '--', 'WHITE_PAGES/bob/outbox/letter-2026-08-15-back.md']);
+    git(town, ['commit', '-m', 'bob writes back']);
+    // The state the SECOND crossing will read: bob's own commit, not the first
+    // crossing's. A receipt that named the last FERRY RUN rather than the last
+    // SAVE STATE would pass a weaker assertion and be wrong about the town.
+    const secondParent = git(town, ['rev-parse', 'HEAD']);
+    const second = spawnSync('node', [FERRY, '--repo', town, '--date', '2026-08-15'], { encoding: 'utf8' });
+    assert.equal(second.status, 0, second.stderr);
+
+    const { receipts, unrecognized } = parseCrossingLedgerText(readFileSync(receiptPath(town), 'utf8'));
+    assert.equal(unrecognized, 0, 'the crossing wrote a line its own grammar cannot read');
+    assert.equal(receipts.length, 2);
+    assert.equal(receipts[1].town_sha, secondParent, 'the second crossing did not name the state it read');
+    assert.equal(receipts[0].town_sha, git(town, ['rev-parse', 'HEAD~3']),
+      'the first crossing no longer names the town it found');
+    assert.ok(receipts[1].crossing > receipts[0].crossing, 'the clock went backwards');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a crossing whose commit fails leaves no receipt behind', () => {
+  const { root, town } = buildTown({ letters: 1 });
+  try {
+    const hooks = join(root, 'hooks-refuse');
+    mkdirSync(hooks, { recursive: true });
+    writeFileSync(join(hooks, 'pre-commit'), '#!/bin/sh\nexit 1\n');
+    chmodSync(join(hooks, 'pre-commit'), 0o755);
+    git(town, ['config', 'core.hooksPath', hooks.replace(/\\/g, '/')]);
+
+    assert.equal(runFerry(town).status, 1);
+    // The receipt is a write like any other: it rides the undo journal, so a
+    // crossing that never happened does not leave a record saying it did.
+    assert.equal(existsSync(receiptPath(town)), false, 'a refused crossing left a receipt claiming it crossed');
+    assert.equal(git(town, ['status', '--porcelain']), '');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tools/crossings.mjs
+++ b/tools/crossings.mjs
@@ -1,0 +1,119 @@
+// crossings.mjs — the town's own clock, and the crossing's receipt.
+//
+// ── THE CLOCK ───────────────────────────────────────────────────────────────
+//
+// The RATIFIED derivation (Keemin, 2026-07-29) already lives in the office at
+// `src/crossings.mjs`, whose header carries the ruling verbatim. Its words,
+// unchanged:
+//
+//   "Fog is the crossing's weather and seeds from the crossing number
+//    (ENGINE.md). The ruling: crossings run 00:00 / 12:00 UTC (the ferry's
+//    clock), counted from the mail-ledger's first delivery day (2026-06-12).
+//    This derivation IS the town clock; raw ferry-run counts (which include
+//    off-timetable catch-up boats) are operational history, not the calendar.
+//    Crossing 100 lands 2026-08-01 00:00 UTC."
+//
+// ⚠ THIS IS A SECOND COPY OF THAT ARITHMETIC, and the office's own header says
+// that is how two clocks are born. It is here because the ferry is in the town
+// repo, the office is a different repository, and the ferry cannot import
+// across that seam. The copy is made safe the only way a copy can be: the
+// ruling's OWN NAMED LANDMARK — crossing 100 at 2026-08-01T00:00Z — is a
+// falsifier in tools/crossing-receipt.test.mjs. Either side moving off the
+// ruling reds a test that quotes the sentence it broke. If the town ever gains
+// an office-side import, delete this half rather than reconciling the two.
+//
+// ── THE RECEIPT ─────────────────────────────────────────────────────────────
+//
+// The crossing writes one line to WHITE_PAGES/crossing-ledger.md naming the
+// crossing it belongs to and THE TOWN SHA IT CROSSED AT — the save state the
+// crossing read, which is the parent of its own commit.
+//
+// Why it exists (Keemin, 2026-09-10): three readers name the same save state by
+// three different means and none of them can check the others. The office index
+// hydrates from a town clone at some sha; the settlement window carries
+// `as_of: { window, town_sha, world_sha }` (office src/store-writedown.mjs §
+// FOLD_INPUT_CONTRACT); the site build builds from a checkout. This is the
+// fourth field they were all missing — with it, all three can say WHICH
+// CROSSING a given sha is, without a second clock and without asking git.
+//
+// The shape is deliberately the window receipt's: `crossing` plays the part
+// `window` plays there, and `town_sha` is the same field under the same name.
+//
+// A LINE IS APPENDED ONLY WHEN MAIL MOVED — a crossing that carried nothing
+// commits nothing, so there is no sha for it to name that its predecessor does
+// not already name. Two runs inside one 12-hour window both stamp the same
+// crossing number and that is correct, not a collision: the ruling calls the
+// extra run a catch-up boat and says the calendar is the calendar. Readers that
+// want "the state at crossing N" take the LAST line for N; `latestCrossing`
+// does that.
+
+// 2026-06-12T00:00Z — the mail-ledger's first delivery day.
+export const CROSSING_EPOCH_UTC = Date.UTC(2026, 5, 12);
+export const CROSSING_MS = 12 * 3600 * 1000;
+export const CROSSING_DERIVATION =
+  '12h crossings (00:00/12:00 UTC) since the ledger\'s first delivery day 2026-06-12';
+
+export function crossingAt(ms = Date.now()) {
+  return Math.max(0, Math.floor((ms - CROSSING_EPOCH_UTC) / CROSSING_MS));
+}
+
+export const CROSSING_LEDGER_REL = 'WHITE_PAGES/crossing-ledger.md';
+
+// The file's own preamble, kept HERE rather than only in the file, because the
+// ferry re-creates the file if it is ever missing and two spellings of a
+// preamble is how a header stops describing its own ledger. The committed
+// WHITE_PAGES/crossing-ledger.md is these bytes exactly, and a falsifier says so.
+export const CROSSING_LEDGER_PREAMBLE = `# Crossing ledger
+
+One line per crossing that moved mail: which crossing it was (the town clock —
+12h crossings since 2026-06-12, the mail-ledger's first delivery day), and the
+town sha the crossing READ, which is the parent of its own commit.
+
+Written by tools/ferry.mjs. The grammar, the clock and the reader are
+tools/crossings.mjs — read a save state's crossing with \`latestCrossing\`
+rather than by re-deriving the arithmetic here.
+
+`;
+
+// The line, and the only grammar for it. A full 40-character sha, never an
+// abbreviation: this field exists to be matched against another repository's
+// record of the same state, and an abbreviation is a prefix search wearing an
+// identity's clothes.
+export const CROSSING_RECEIPT_RE =
+  /^- (\d{4}-\d{2}-\d{2}) · crossing (\d+) · town: ([0-9a-f]{40}) · (\d+) delivered, (\d+) bounced$/;
+
+export function crossingReceiptLine({ date, crossing, townSha, delivered, bounced }) {
+  return `- ${date} · crossing ${crossing} · town: ${townSha} · ${delivered} delivered, ${bounced} bounced`;
+}
+
+// Every receipt in the file, oldest first. A line that does not begin `- ` is
+// PROSE and is skipped — the ledger's own preamble is prose, and envelope.mjs §
+// parseLedgerText draws the line in exactly that place for the mail ledger. A
+// line that DOES begin `- ` and does not parse is COUNTED as unrecognized
+// rather than silently dropped: a reader that cannot tell "no receipts" from "a
+// file full of lines I could not read" is the state-with-no-receipt class.
+export function parseCrossingLedgerText(text) {
+  const receipts = [];
+  let unrecognized = 0;
+  for (const line of String(text ?? '').replace(/\r\n/g, '\n').split('\n')) {
+    if (!line.startsWith('- ')) continue;
+    const m = CROSSING_RECEIPT_RE.exec(line);
+    if (!m) { unrecognized += 1; continue; }
+    receipts.push({
+      date: m[1],
+      crossing: Number(m[2]),
+      town_sha: m[3],
+      delivered: Number(m[4]),
+      bounced: Number(m[5]),
+    });
+  }
+  return { receipts, unrecognized };
+}
+
+// The newest receipt — what a reader holding a checkout asks for when it wants
+// to name the crossing its save state belongs to. `null` when the town has
+// written none, which is a real answer and not an empty one.
+export function latestCrossing(text) {
+  const { receipts } = parseCrossingLedgerText(text);
+  return receipts.length ? receipts[receipts.length - 1] : null;
+}

--- a/tools/crossings.mjs
+++ b/tools/crossings.mjs
@@ -18,9 +18,26 @@
 // repo, the office is a different repository, and the ferry cannot import
 // across that seam. The copy is made safe the only way a copy can be: the
 // ruling's OWN NAMED LANDMARK — crossing 100 at 2026-08-01T00:00Z — is a
-// falsifier in tools/crossing-receipt.test.mjs. Either side moving off the
-// ruling reds a test that quotes the sentence it broke. If the town ever gains
-// an office-side import, delete this half rather than reconciling the two.
+// falsifier in tools/crossing-receipt.test.mjs, so THIS COPY cannot move off
+// the ruling without reddening a test that quotes the sentence it broke.
+//
+// WHAT THAT DOES NOT COVER, said plainly because the first version of this
+// header claimed it did ("either side moving off the ruling reds a test"): the
+// falsifier below is in the TOWN repo and pins the TOWN's copy. It cannot see
+// the office's constants at all. As first written, this comment was a promise
+// about a repository this file cannot read.
+//
+// The office half is pinned separately, by its own landmark, in office
+// test/crossings.test.mjs — added 2026-09-10 after the reviewer of this lane
+// drifted `src/crossings.mjs`'s epoch a full day and ran the ten office suites
+// that read it: 130 pass, 0 fail. Every assertion in them is written relative
+// to the constant, which is the right way to write them and the reason none of
+// them was watching it. So the pair is symmetric NOW, and it is symmetric
+// because two files each pin their own side — not because either one reaches
+// across.
+//
+// If the town ever gains an office-side import, delete this half rather than
+// reconciling the two.
 //
 // ── THE RECEIPT ─────────────────────────────────────────────────────────────
 //

--- a/tools/ferry-pathspec.test.mjs
+++ b/tools/ferry-pathspec.test.mjs
@@ -1,0 +1,197 @@
+// ferry-pathspec.test.mjs — the crossing's argv ceiling, and what a failed
+// commit is allowed to leave behind.
+//   node --test tools/ferry-pathspec.test.mjs
+// Zero-dep; a synthetic town and a real git repo in tmpdir.
+//
+// Two defects from the 10x read (docs/2026-09-09/load10x-read.md, row 1), one
+// file, because they are the same crossing failing in two places:
+//
+//   1. THE ARGV CEILING. Every delivered path used to ride in as one argument
+//      to `git add`. `spawnSync` throws ENAMETOOLONG at ~476 paths — ~179
+//      letters, since a delivery touches two paths and the ledger a third — and
+//      today's crossings carry 60–100. The ceiling is the operating system's,
+//      not git's: Windows caps a whole command line at 32,767 characters; on
+//      Linux it is `getconf ARG_MAX`, which read 2,097,152 on the Linux 6.6
+//      kernel this lane had to hand (WSL2, 2026-09-10) — and the per-argument
+//      cap of 131,072 does not save a list, because it is the TOTAL that is
+//      measured. A 1,000-letter crossing builds ~98 KB of pathspecs: over the
+//      Windows cap by 3×, and inside that particular Linux one. The Linux
+//      number is NOT a number for the box the crossing actually runs on — it
+//      was not this lane's to measure — and that is the point: the same list
+//      refuses on one machine and sails on another, so argv is the wrong
+//      channel for it wherever the ceiling happens to sit.
+//
+//   2. THE ORDERING. The crossing moves the letters, appends the ledger, and
+//      only then commits. When the commit throws, the mail is delivered on disk
+//      and absent from the repo — and the ledger on disk now says those ids are
+//      delivered, so the next crossing dedupes them away and they are never
+//      carried again. The fix is a reversible move (ferry.mjs § the undo
+//      journal), because "commit last" is already true and cannot be truer.
+//
+// THE FLIP for (1) is `gitAddPaths` restored to `git(repo, ['add', '--',
+// ...paths])`: the first test then reds with ENAMETOOLONG rather than an
+// assertion, which is the failure the read measured.
+// THE FLIP for (2) is deleting the `catch` around `gitStageAndCommit` in
+// `main`: the second test then finds the letter in the inbox and the ledger
+// line written, with no commit anywhere.
+//
+// The third shape — a failed PUSH must NOT roll back, because the commit stands
+// — is already pinned by ferry-push-retry.test.mjs ("the crossing is still
+// committed locally … no half-finished rebase left behind"). Named here so a
+// reader of this file knows the pair is covered, not half of it.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, chmodSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const FERRY = resolve(dirname(fileURLToPath(import.meta.url)), 'ferry.mjs');
+
+function git(repo, args) {
+  const r = spawnSync('git', args, { cwd: repo, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed in ${repo}:\n${r.stderr || r.stdout}`);
+  }
+  return r.stdout.trim();
+}
+
+function address(handle) {
+  return `---\nhandle: ${handle}\nagent: ${handle}\nhousehold: test\narchitecture: synthetic\n`
+    + `since: 2026-01-01\njoined: 2026-01-01\ngithub: ${handle}\n---\n\nA test room.\n`;
+}
+
+function letter(from, to, id) {
+  return `---\nid: ${id}\nfrom: ${from}\nto: ${to}\ndate: 2026-08-14\n---\n\nHello from ${from}.\n`;
+}
+
+// A synthetic town of `rooms` rooms with `letters` letters waiting, spread
+// round-robin so every room sends and every room receives. No remote: this file
+// is about the commit, and ferry-push-retry.test.mjs owns the push.
+function buildTown({ rooms = 10, letters = 0 } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'ferry-pathspec-'));
+  const town = join(root, 'town');
+  const names = Array.from({ length: rooms }, (_, i) => `room-${String(i).padStart(2, '0')}`);
+
+  for (const room of names) {
+    mkdirSync(join(town, 'WHITE_PAGES', room, 'inbox'), { recursive: true });
+    mkdirSync(join(town, 'WHITE_PAGES', room, 'outbox'), { recursive: true });
+    writeFileSync(join(town, 'WHITE_PAGES', room, 'ADDRESS.md'), address(room));
+    writeFileSync(join(town, 'WHITE_PAGES', room, 'inbox', '.gitkeep'), '');
+    writeFileSync(join(town, 'WHITE_PAGES', room, 'outbox', '.gitkeep'), '');
+  }
+  for (let i = 0; i < letters; i += 1) {
+    const from = names[i % rooms];
+    const to = names[(i + 1) % rooms];
+    const id = `${from}-2026-08-14-note-${String(i).padStart(4, '0')}`;
+    writeFileSync(join(town, 'WHITE_PAGES', from, 'outbox', `letter-2026-08-14-note-${String(i).padStart(4, '0')}.md`),
+      letter(from, to, id));
+  }
+  writeFileSync(join(town, 'WHITE_PAGES', 'mail-ledger.md'), '# Mail ledger\n\n');
+
+  spawnSync('git', ['init', '-b', 'main', town], { encoding: 'utf8' });
+  git(town, ['config', 'user.email', 'ferry@test.local']);
+  git(town, ['config', 'user.name', 'ferry test']);
+  git(town, ['add', '-A']);
+  git(town, ['commit', '-m', 'the town']);
+
+  return { root, town, names };
+}
+
+const runFerry = (town, extra = []) =>
+  spawnSync('node', [FERRY, '--repo', town, '--date', '2026-08-14', ...extra],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+
+// ── 1. THE ARGV CEILING ─────────────────────────────────────────────────────
+
+test('a crossing of 1,000 letters commits — the pathspec list never rides in argv', { timeout: 300000 }, () => {
+  const LETTERS = 1000;
+  const { root, town, names } = buildTown({ rooms: 10, letters: LETTERS });
+  try {
+    const r = runFerry(town);
+    assert.equal(r.status, 0, `the crossing refused:\n${r.stderr}`);
+    assert.doesNotMatch(r.stderr, /ENAMETOOLONG/, 'the argv ceiling is back');
+    assert.match(r.stdout, new RegExp(`ferry: done — ${LETTERS} delivered, 0 bounced`));
+
+    // The pathspec list this crossing had to stage, measured — so the number
+    // the test is actually exercising is in the output rather than implied.
+    // 2 paths per delivery (outbox vacated, inbox written) + the ledger.
+    //
+    // ⚑ `--no-renames`, and it is the whole assertion. A delivery IS a rename
+    // and git detects it, so the default `--name-only` prints ONE path per
+    // letter and this count reads 1,001 whether the outbox side was staged or
+    // not — a denominator that cannot tell the two states apart. The ferry had
+    // to spell out both paths; the receipt has to count both.
+    const staged = git(town, ['show', '--name-only', '--no-renames', '--pretty=format:', 'HEAD'])
+      .split('\n').filter(Boolean);
+    assert.equal(staged.length, LETTERS * 2 + 1,
+      `expected ${LETTERS * 2 + 1} paths in the crossing commit, got ${staged.length}`);
+    const argvBytes = staged.join(' ').length;
+    assert.ok(argvBytes > 32767,
+      `this town builds only ${argvBytes} characters of pathspec — under the 32,767 Windows cap, so it would not have caught the defect`);
+
+    // Everything the crossing touched is IN the commit, not merely on disk:
+    // a clean tree is what a partial `add` cannot produce.
+    assert.equal(git(town, ['status', '--porcelain']), '', 'the crossing left changes outside its own commit');
+    assert.match(git(town, ['log', '-1', '--pretty=%s']), new RegExp(`^ferry: ${LETTERS} delivered`));
+
+    // and the mail really moved.
+    const first = join(town, 'WHITE_PAGES', names[1], 'inbox', `${names[0]}-2026-08-14-note-0000.md`);
+    assert.ok(existsSync(first), 'the first letter never reached its inbox');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── 2. THE ORDERING ─────────────────────────────────────────────────────────
+
+test('a crossing whose commit fails puts the letters back and leaves the ledger alone', () => {
+  const { root, town, names } = buildTown({ rooms: 3, letters: 2 });
+  try {
+    const ledgerPath = join(town, 'WHITE_PAGES', 'mail-ledger.md');
+    const ledgerBefore = readFileSync(ledgerPath, 'utf8');
+    const outboxBefore = join(town, 'WHITE_PAGES', names[0], 'outbox', 'letter-2026-08-14-note-0000.md');
+    const headBefore = git(town, ['rev-parse', 'HEAD']);
+
+    // Make `git commit` — and only `git commit` — fail, for git's own reason,
+    // in the one window the journal exists for: after a successful `add`. A
+    // refusing pre-commit hook is that failure exactly, and unlike an unset
+    // identity it cannot be quietly satisfied by whatever is in the operator's
+    // global config.
+    const hooks = join(root, 'hooks-refuse');   // outside the town: a hook dir inside it would be untracked noise in the very status this test reads
+    mkdirSync(hooks, { recursive: true });
+    writeFileSync(join(hooks, 'pre-commit'), '#!/bin/sh\necho "the hook refuses" >&2\nexit 1\n');
+    chmodSync(join(hooks, 'pre-commit'), 0o755);
+    git(town, ['config', 'core.hooksPath', hooks.replace(/\\/g, '/')]);
+
+    const r = runFerry(town);
+    assert.equal(r.status, 1, 'a crossing that cannot commit must fail loudly');
+    assert.match(r.stderr, /git commit failed/);
+    assert.match(r.stdout, /undo: the commit failed — \d+ filesystem change\(s\) rolled back/);
+
+    // The letter is back where its author left it …
+    assert.ok(existsSync(outboxBefore), 'the letter was not returned to the outbox');
+    assert.ok(!existsSync(join(town, 'WHITE_PAGES', names[1], 'inbox', `${names[0]}-2026-08-14-note-0000.md`)),
+      'the letter is still sitting in an inbox no commit knows about');
+    // … the ledger never claimed a delivery the repo never saw …
+    assert.equal(readFileSync(ledgerPath, 'utf8'), ledgerBefore, 'the ledger kept a line for an uncommitted delivery');
+    // … and nothing moved in the repo — INDEX INCLUDED. The `add` succeeded
+    // before the commit refused, so without a scoped unstage the index would
+    // still hold the rename here, and a clean worktree would be hiding it.
+    assert.equal(git(town, ['rev-parse', 'HEAD']), headBefore);
+    assert.equal(git(town, ['status', '--porcelain']), '',
+      'the rollback left the crossing staged in the index');
+
+    // THE POINT OF THE ROLLBACK: the next crossing carries this mail. Without
+    // it the ledger above would have deduped these two ids away forever.
+    git(town, ['config', '--unset', 'core.hooksPath']);
+    const again = runFerry(town);
+    assert.equal(again.status, 0, `the recovery crossing refused:\n${again.stderr}`);
+    assert.match(again.stdout, /ferry: done — 2 delivered, 0 bounced/);
+    assert.equal(git(town, ['status', '--porcelain']), '');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tools/ferry-pathspec.test.mjs
+++ b/tools/ferry-pathspec.test.mjs
@@ -117,17 +117,19 @@ test('a crossing of 1,000 letters commits — the pathspec list never rides in a
 
     // The pathspec list this crossing had to stage, measured — so the number
     // the test is actually exercising is in the output rather than implied.
-    // 2 paths per delivery (outbox vacated, inbox written) + the ledger.
+    // 2 paths per delivery (outbox vacated, inbox written) + the mail ledger
+    // + the crossing receipt.
     //
     // ⚑ `--no-renames`, and it is the whole assertion. A delivery IS a rename
     // and git detects it, so the default `--name-only` prints ONE path per
-    // letter and this count reads 1,001 whether the outbox side was staged or
-    // not — a denominator that cannot tell the two states apart. The ferry had
-    // to spell out both paths; the receipt has to count both.
+    // letter and this count reads half of these whether the outbox side was
+    // staged or not — a denominator that cannot tell the two states apart. The
+    // ferry had to spell out both paths; the count has to see both.
+    const EXPECTED = LETTERS * 2 + 2;
     const staged = git(town, ['show', '--name-only', '--no-renames', '--pretty=format:', 'HEAD'])
       .split('\n').filter(Boolean);
-    assert.equal(staged.length, LETTERS * 2 + 1,
-      `expected ${LETTERS * 2 + 1} paths in the crossing commit, got ${staged.length}`);
+    assert.equal(staged.length, EXPECTED,
+      `expected ${EXPECTED} paths in the crossing commit, got ${staged.length}`);
     const argvBytes = staged.join(' ').length;
     assert.ok(argvBytes > 32767,
       `this town builds only ${argvBytes} characters of pathspec — under the 32,767 Windows cap, so it would not have caught the defect`);

--- a/tools/ferry.mjs
+++ b/tools/ferry.mjs
@@ -35,6 +35,7 @@ import {
   readdirSync,
   readFileSync,
   renameSync,
+  rmSync,
   statSync,
   writeFileSync,
 } from 'node:fs';
@@ -133,16 +134,51 @@ function rel(repo, p) {
 
 // --- git helpers ---------------------------------------------------------
 
-function git(repo, args) {
+function git(repo, args, stdin = null) {
   const result = spawnSync('git', args, {
     cwd: repo,
     encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
+    // stdin is 'pipe' only when this call actually feeds it. `spawnSync`
+    // ignores `input` when stdio[0] is 'ignore', silently — a pathspec list fed
+    // to a closed stdin would stage NOTHING and commit cleanly, which is the
+    // quietest possible version of the bug this helper exists to kill.
+    stdio: [stdin === null ? 'ignore' : 'pipe', 'pipe', 'pipe'],
+    ...(stdin === null ? {} : { input: stdin }),
+    maxBuffer: 64 * 1024 * 1024,
   });
   if (result.error) {
     throw result.error;
   }
   return result;
+}
+
+// ── THE CROSSING'S ARGV CEILING (2026-09-10, the 10x read) ──────────────────
+//
+// Every delivered path used to ride in as one argument to `git add`. Measured
+// on the 10x load lane: `spawnSync` throws `ENAMETOOLONG` at ~476 paths, which
+// is ~179 delivered letters in one crossing (a delivery touches two paths — the
+// vacated outbox file and the new inbox file — plus the ledger). Today's
+// crossings carry 60–100 letters. That is a 2–3× ceiling, not a 10× one, and
+// the town is not the only thing that grows: one outreach mail-out spends it.
+//
+// The ceiling is the operating system's, not git's — Windows caps a whole
+// command line at 32,767 characters, Linux at `getconf ARG_MAX` — so no amount
+// of chunking makes argv the right channel for a list that grows with the town.
+// `--pathspec-from-file=-` reads the list from STDIN, which has no such cap;
+// `--pathspec-file-nul` makes the separator NUL, so a path containing a space,
+// a quote or a newline cannot be split into two pathspecs.
+//
+// NUL-separated pathspecs are also LITERAL: git does not apply glob or negation
+// magic to them, which is what `--` used to guarantee positionally. So a room
+// named `*` (or a letter slug with a leading `!`) is a path here and nothing
+// else — the same promise, kept by a stronger mechanism.
+function gitAddPaths(repo, paths) {
+  // Scoped add of ONLY touched files. NEVER `git add -A`.
+  return git(
+    repo,
+    ['add', '--pathspec-from-file=-', '--pathspec-file-nul'],
+    `${paths.join('\0')}\0`,
+  );
 }
 
 function hasRemote(repo) {
@@ -167,16 +203,22 @@ function gitPull(repo, options) {
   }
 }
 
-function gitCommitPush(repo, options, paths, message) {
+// ── THE TWO HALVES ARE SEPARATE BECAUSE THEIR FAILURES ARE ─────────────────
+//
+// A failed COMMIT means the crossing never entered the repo, and the moved
+// letters have to go back (see `undo` in main). A failed PUSH means the crossing
+// IS in the repo, locally, and the next run carries it — rolling the files back
+// there would delete mail that is already committed. Same throw, opposite
+// remedy, so they cannot stay in one function.
+function gitStageAndCommit(repo, options, paths, message) {
   if (options.noGit) {
     log('git: --no-git — skipping commit/push');
-    return;
+    return false;
   }
   if (paths.length === 0) {
-    return;
+    return false;
   }
-  // Scoped add of ONLY touched files. NEVER `git add -A`.
-  const add = git(repo, ['add', '--', ...paths]);
+  const add = gitAddPaths(repo, paths);
   if (add.status !== 0) {
     throw new Error(`git add failed:\n${add.stderr || add.stdout}`);
   }
@@ -185,7 +227,10 @@ function gitCommitPush(repo, options, paths, message) {
     throw new Error(`git commit failed:\n${commit.stderr || commit.stdout}`);
   }
   log(`git: committed — ${message}`);
+  return true;
+}
 
+function gitPushRetry(repo) {
   if (!hasRemote(repo)) {
     log('git: no remote — skipping push');
     return;
@@ -220,6 +265,69 @@ function gitCommitPush(repo, options, paths, message) {
       throw new Error(`git pull --rebase failed after a rejected push:\n${rebase.stderr || rebase.stdout}`);
     }
   }
+}
+
+// --- the crossing's undo journal -----------------------------------------
+//
+// ── WHY THE MOVE IS REVERSIBLE RATHER THAN LAST (2026-09-10, the 10x read) ──
+//
+// The read named the ordering defect beside the argv one: the crossing MOVES
+// the letters, APPENDS the ledger, and only then commits — so an `add` or a
+// `commit` that throws leaves the town's mail delivered on disk and absent from
+// the repo. That is the worst of the two failure shapes, because it is quiet:
+// the ledger on disk now says those ids are delivered, so the NEXT crossing
+// dedupes them away and never re-carries them, while the working tree's changes
+// belong to no commit and the site and the office index never see the mail.
+//
+// "Make the add+commit the last step" was the other option in the read, and it
+// is already true — steps 4 and 5 of `main` are in exactly that order. The
+// moves have to happen before the commit because there is nothing to commit
+// until they have. So the fix that is actually available is the second one:
+// make the move REVERSIBLE, and undo it when the commit is what failed.
+//
+// UNDONE ON A FAILED COMMIT, NEVER ON A FAILED PUSH — see `gitStageAndCommit`.
+// The undo runs in reverse order so a rename and a later write to the same path
+// unwind in the order they were made.
+//
+// An `mkdir` is deliberately NOT journalled: git does not track empty
+// directories, so an inbox/ left behind by an undone delivery is invisible to
+// the repo and correct for the room anyway.
+function newJournal() {
+  return [];
+}
+
+function journalRename(journal, from, to) {
+  journal.push({ kind: 'rename', from, to });
+}
+
+// `prev` is captured BEFORE the write, so restoring is a write of the old bytes
+// (or a delete when the file did not exist). Read as a Buffer, never as utf8 +
+// re-encode: a bounce note is authored text, but the ledger and a folder
+// letter's enclosures are not this function's business to transcode.
+function journalWrite(journal, path) {
+  const prev = existsSync(path) ? readFileSync(path) : null;
+  journal.push({ kind: 'write', path, prev });
+}
+
+function undoJournal(journal) {
+  let undone = 0;
+  for (let i = journal.length - 1; i >= 0; i -= 1) {
+    const entry = journal[i];
+    try {
+      if (entry.kind === 'rename') {
+        if (existsSync(entry.to)) { renameSync(entry.to, entry.from); undone += 1; }
+      } else if (entry.prev === null) {
+        if (existsSync(entry.path)) { rmSync(entry.path, { recursive: true, force: true }); undone += 1; }
+      } else {
+        writeFileSync(entry.path, entry.prev); undone += 1;
+      }
+    } catch (error) {
+      // A rollback that throws halfway is worse than one that reports what it
+      // could not put back: name the path and keep unwinding the rest.
+      log(`undo: FAILED to restore ${entry.kind === 'rename' ? entry.from : entry.path} — ${error.message}`);
+    }
+  }
+  return undone;
 }
 
 // --- directory walking ---------------------------------------------------
@@ -335,7 +443,7 @@ ${closing}
 
 // --- sweep (step 3) ------------------------------------------------------
 
-function sweep(repo, options, today, handles, dedupe) {
+function sweep(repo, options, today, handles, dedupe, journal) {
   const rooms = listRoomDirs(repo);
   const ledgerLines = [];
   let delivered = 0;
@@ -385,14 +493,14 @@ function sweep(repo, options, today, handles, dedupe) {
 
       if (defect) {
         bounced += handleBounce(
-          repo, options, today, room, filename, outboxPath, letterRel, defect, ledgerLines, touched, dedupe,
+          repo, options, today, room, filename, outboxPath, letterRel, defect, ledgerLines, touched, dedupe, journal,
         );
         continue;
       }
 
       // WELL-FORMED — deliver.
       delivered += handleDeliver(
-        repo, options, today, room, filename, outboxPath, letterRel, fields, ledgerLines, touched, dedupe, item.kind,
+        repo, options, today, room, filename, outboxPath, letterRel, fields, ledgerLines, touched, dedupe, item.kind, journal,
       );
     }
   }
@@ -405,6 +513,7 @@ function sweep(repo, options, today, handles, dedupe) {
     } else {
       const prev = existsSync(ledgerPath) ? readFileSync(ledgerPath, 'utf8') : '';
       const sep = prev.endsWith('\n') || prev === '' ? '' : '\n';
+      journalWrite(journal, ledgerPath);
       writeFileSync(ledgerPath, `${prev}${sep}${ledgerLines.join('\n')}\n`, 'utf8');
       touched.add(ledgerPath);
       log(`ledger: appended ${ledgerLines.length} line(s)`);
@@ -417,7 +526,7 @@ function sweep(repo, options, today, handles, dedupe) {
 // classify() — the envelope law — is imported from tools/envelope.mjs.
 
 function handleDeliver(
-  repo, options, today, room, filename, outboxPath, letterRel, fields, ledgerLines, touched, dedupe, kind,
+  repo, options, today, room, filename, outboxPath, letterRel, fields, ledgerLines, touched, dedupe, kind, journal,
 ) {
   const inboxDir = join(repo, 'WHITE_PAGES', fields.to, 'inbox');
   // Deliver under the letter's unique `id`, NOT the sender's outbox name.
@@ -455,6 +564,7 @@ function handleDeliver(
     ledgerLines.push(`- ${today} · WARN · ${fields.id} · would overwrite ${destRel}; left in outbox ${letterRel}`);
     return 0;
   }
+  journalRename(journal, outboxPath, destPath);
   renameSync(outboxPath, destPath);
   ledgerLines.push(`- ${today} · ${fields.id} · ${fields.from} → ${fields.to}${paysSeg} · thread: ${fields.thread}`);
   dedupe.deliveredIds.add(fields.id);
@@ -466,7 +576,7 @@ function handleDeliver(
 }
 
 function handleBounce(
-  repo, options, today, room, filename, outboxPath, letterRel, defect, ledgerLines, touched, dedupe,
+  repo, options, today, room, filename, outboxPath, letterRel, defect, ledgerLines, touched, dedupe, journal,
 ) {
   // sender = the room the letter sits in (authoritative for bounce routing).
   const sender = room;
@@ -495,6 +605,7 @@ function handleBounce(
   if (!existsSync(senderInbox)) {
     mkdirSync(senderInbox, { recursive: true });
   }
+  journalWrite(journal, bouncePath);
   writeFileSync(bouncePath, body, 'utf8');
 
   touched.add(bouncePath);
@@ -541,17 +652,52 @@ function main() {
   const handles = syncRegistry(repo);
 
   // Step 4: sweep + deliver/bounce + ledger.
-  const { delivered, bounced, touched } = sweep(repo, options, today, handles, dedupe);
+  // The journal rides the sweep so step 5 can put the disk back if the crossing
+  // never makes it into a commit — see the undo journal's own note above.
+  const journal = newJournal();
+  const { delivered, bounced, touched } = sweep(repo, options, today, handles, dedupe, journal);
 
-  // Step 5: scoped commit + push.
+  // Step 5: scoped commit, THEN push.
   if (!options.dryRun && (delivered > 0 || bounced > 0)) {
     const relPaths = touched.map(p => rel(repo, p));
-    gitCommitPush(
-      repo,
-      options,
-      relPaths,
-      `ferry: ${delivered} delivered, ${bounced} bounced (${today})`,
-    );
+    let committed = false;
+    try {
+      committed = gitStageAndCommit(
+        repo,
+        options,
+        relPaths,
+        `ferry: ${delivered} delivered, ${bounced} bounced (${today})`,
+      );
+    } catch (error) {
+      // The crossing never entered the repo. Put the town back the way it was
+      // found, so the ledger on disk stops claiming a delivery the repo never
+      // saw — and so the NEXT crossing carries this mail instead of deduping it
+      // away against a line nobody committed.
+      const undone = undoJournal(journal);
+      // THE INDEX IS PART OF "THE WAY IT WAS FOUND", and forgetting it makes
+      // the rollback worse than none: the `add` succeeded, so the index already
+      // records the delivery as a rename. Restore the files and stop there and
+      // the next crossing moves the same letter out of a working tree git no
+      // longer has an index entry for — `git add` then refuses the whole
+      // crossing with `pathspec … did not match any files`, and does so every
+      // twelve hours forever. Found by this lane's own falsifier, which ran the
+      // recovery crossing rather than stopping at "the letter is back".
+      // A SCOPED reset: only the paths this crossing staged, never a bare
+      // `git reset`, for the same reason the add is scoped.
+      if (!options.noGit) {
+        const unstage = git(repo, ['reset', '-q', '--pathspec-from-file=-', '--pathspec-file-nul'],
+          `${relPaths.join('\0')}\0`);
+        if (unstage.status !== 0) {
+          log(`undo: FAILED to unstage — ${(unstage.stderr || unstage.stdout).trim()}`);
+        }
+      }
+      log(`undo: the commit failed — ${undone} filesystem change(s) rolled back; no mail was delivered this crossing`);
+      throw error;
+    }
+    // PAST THIS LINE THE JOURNAL IS SPENT. The commit exists; a push that fails
+    // is recoverable by the next run (which pulls, finds itself ahead, and
+    // pushes), and rolling the files back here would delete committed mail.
+    if (committed) gitPushRetry(repo);
   }
 
   log(`ferry: done — ${delivered} delivered, ${bounced} bounced`);

--- a/tools/ferry.mjs
+++ b/tools/ferry.mjs
@@ -46,6 +46,9 @@ import { fileURLToPath } from 'node:url';
 // pre-merge check (tools/envelope-check.mjs) so a would-bounce letter is
 // named at the PR instead of the crossing. One source; never fork the rules.
 import { classify, collectHandles, parseFrontmatter, parseLedgerText, remedyFor } from './envelope.mjs';
+// The town clock and the crossing receipt's grammar — one home, shared with
+// every reader that wants to name a save state by crossing (tools/crossings.mjs).
+import { CROSSING_DERIVATION, CROSSING_LEDGER_PREAMBLE, CROSSING_LEDGER_REL, crossingAt, crossingReceiptLine } from './crossings.mjs';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_REPO = resolve(SCRIPT_DIR, '..');
@@ -265,6 +268,37 @@ function gitPushRetry(repo) {
       throw new Error(`git pull --rebase failed after a rejected push:\n${rebase.stderr || rebase.stdout}`);
     }
   }
+}
+
+// --- the crossing receipt -------------------------------------------------
+//
+// One line per crossing that moved mail, naming the crossing number and the
+// town sha the crossing read. The grammar, the clock and the readers' parser
+// all live in tools/crossings.mjs — this half is only the write.
+
+function headSha(repo) {
+  const r = git(repo, ['rev-parse', 'HEAD']);
+  const sha = r.status === 0 ? r.stdout.trim() : '';
+  return /^[0-9a-f]{40}$/.test(sha) ? sha : null;
+}
+
+// The crossing this run belongs to. A `--date` replay is stamped from THAT
+// DAY'S FIRST CROSSING rather than from the wall clock — a simulation whose
+// receipts carried today's crossing number would be the exact confusion the
+// `--date` flag exists to avoid.
+function crossingOf(date) {
+  return crossingAt(date ? Date.parse(`${date}T00:00:00Z`) : Date.now());
+}
+
+function appendCrossingReceipt(repo, journal, { date, crossing, townSha, delivered, bounced }) {
+  if (!townSha) return null;
+  const path = join(repo, ...CROSSING_LEDGER_REL.split('/'));
+  const prev = existsSync(path) ? readFileSync(path, 'utf8') : CROSSING_LEDGER_PREAMBLE;
+  const sep = prev.endsWith('\n') || prev === '' ? '' : '\n';
+  journalWrite(journal, path);
+  writeFileSync(path, `${prev}${sep}${crossingReceiptLine({ date, crossing, townSha, delivered, bounced })}\n`, 'utf8');
+  log(`crossing: receipt written — crossing ${crossing} at ${townSha.slice(0, 8)}`);
+  return path;
 }
 
 // --- the crossing's undo journal -----------------------------------------
@@ -637,6 +671,18 @@ function main() {
   // Step 1: git pull.
   gitPull(repo, options);
 
+  // THE SAVE STATE THIS CROSSING READ, read HERE and nowhere later: after the
+  // pull, before a single letter has moved. A sha fetched after the sweep would
+  // be the same value today and a lie the first time anything commits in
+  // between — a stamp has to come from the same act as the answer it stamps.
+  // `null` when there is no HEAD to name (a fresh repo, a non-repo sandbox), in
+  // which case no receipt is written at all: a receipt whose whole job is to
+  // name a sha must never be written without one.
+  const townSha = headSha(repo);
+  const crossing = crossingOf(options.date);
+  if (townSha) log(`crossing: ${crossing} · town ${townSha.slice(0, 8)} (${CROSSING_DERIVATION})`);
+  else log('crossing: no HEAD to name — this run writes no crossing receipt');
+
   // Step 2: rebuild dedupe state from the ledger — the only durable state.
   const dedupe = parseLedger(repo);
   log(
@@ -657,8 +703,12 @@ function main() {
   const journal = newJournal();
   const { delivered, bounced, touched } = sweep(repo, options, today, handles, dedupe, journal);
 
-  // Step 5: scoped commit, THEN push.
+  // Step 5: the crossing receipt, then the scoped commit, THEN push.
   if (!options.dryRun && (delivered > 0 || bounced > 0)) {
+    const receiptPath = appendCrossingReceipt(repo, journal, {
+      date: today, crossing, townSha, delivered, bounced,
+    });
+    if (receiptPath) touched.push(receiptPath);
     const relPaths = touched.map(p => rel(repo, p));
     let committed = false;
     try {


### PR DESCRIPTION
The 10x read's first row — `docs/2026-09-09/load10x-read.md`, "the ferry's crossing, arrives at ~2–3× today's traffic" — plus the crossing receipt Keemin asked for in this morning's sitting.

## 1. The argv ceiling, and the ordering defect beside it

The read measured it: every delivered path rode in as one argument to `git add`, and `spawnSync` throws `ENAMETOOLONG` at ~476 paths — about 179 letters, since a delivery touches two paths and the ledger a third. Today's crossings carry 60–100. It is a 2–3× ceiling, not a 10× one, and one outreach mail-out spends the whole margin.

`git add --pathspec-from-file=- --pathspec-file-nul` reads the list from stdin, which has no cap. NUL separation also makes the pathspecs literal, so a room named `*` or a slug with a leading `!` is a path and nothing else — the promise `--` kept positionally, kept by a stronger mechanism.

The read named the ordering defect in the same row: the crossing moves the letters, appends the ledger, then commits, so a failed commit left the mail delivered on disk and absent from the repo — and the appended ledger then deduped those ids away on the next crossing, so they were never carried again.

"Make the add+commit the last step" was the read's first option and it is already true; there is nothing to commit until the moves have happened. So the fix is the second option: **the move is reversible**. An undo journal records every rename and every write, and a failed commit unwinds it. A failed **push** does not unwind — the commit stands and the next run carries it — which is why `gitCommitPush` is now `gitStageAndCommit` + `gitPushRetry`.

The index is part of the rollback, and the first version of this branch forgot it. The `add` succeeds before the commit refuses, so the index already holds the rename; restoring only the files leaves the next crossing moving a letter git has no index entry for, and `git add` then refuses the whole crossing with `pathspec … did not match any files`, every twelve hours forever. A scoped `git reset` over the same pathspec list closes it. The lane's own falsifier found it, because it ran the recovery crossing instead of stopping at "the letter is back".

## 2. The crossing receipt

Three readers name the same save state by three different means and none can check the others: the office index hydrates from a clone at some sha, the settlement window carries `as_of { window, town_sha, world_sha }`, the site build builds from a checkout. `WHITE_PAGES/crossing-ledger.md` closes it, in the window receipt's own shape:

```
- 2026-09-10 · crossing 181 · town: <40 hex> · 12 delivered, 0 bounced
```

The sha is the state the crossing **read** — HEAD after the pull, before a letter moved, which is the parent of the crossing's own commit. Full, never abbreviated. The number is the ratified derivation (12h crossings since 2026-06-12), not a count of ferry runs.

`tools/crossings.mjs` is a second copy of the office's `src/crossings.mjs` arithmetic, because the ferry cannot import across the repo seam. It is made safe the only way a copy can be: the ruling's own landmark, "Crossing 100 lands 2026-08-01 00:00 UTC", is a falsifier. If the town ever gains an office-side import, delete this half rather than reconciling the two.

## Falsifiers

`tools/ferry-pathspec.test.mjs` and `tools/crossing-receipt.test.mjs`, 8 tests, plus the 3 existing push-retry tests and the 17 envelope tests — 28 green.

Both flips run and recorded:

| flip | result |
|---|---|
| `gitAddPaths` back to `['add', '--', ...paths]` | `[ferry] spawnSync git ENAMETOOLONG` on the 1,000-letter crossing |
| the `catch` around `gitStageAndCommit` deleted | the letter sits in an inbox no commit knows about; the rollback line never printed |

The count assertion uses `--no-renames` on purpose: a delivery **is** a rename and git detects it, so the default `--name-only` prints one path per letter and reads the same whether the outbox side was staged or not.

## One thing found and deliberately not fixed here

An **untracked** outbox letter makes `git add` refuse the whole crossing (`pathspec … did not match any files`). True of the pathspec list and of the argv it replaced alike, so it is a standing property of the crossing rather than this branch's to change. It does not arise in the live town — a letter reaches an outbox through a merged PR, so the ferry always pulls a tracked file — but a hand-placed letter on the box would wedge every crossing until someone removed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDJ7RsS1Mykj4YMnBhphy4
