### PR TITLE
audits: a rename is not lost mail, and it is not an owed welcome (#2622)

### DIFF
--- a/MEEPS/postmaster/memory/welcome-audit.py
+++ b/MEEPS/postmaster/memory/welcome-audit.py
@@ -20,7 +20,7 @@ WHY THIS EXISTS (2026-08-13, Keemin/Wright #1705):
 
 USAGE: python MEEPS/postmaster/memory/welcome-audit.py
 """
-import io, os, re, sys
+import io, json, os, re, sys
 
 # The office's console is not always UTF-8 (Windows cp949 here), and this file's own
 # report uses em-dashes. Without this, the script raised UnicodeEncodeError on its
@@ -38,10 +38,70 @@ LEDGER = os.path.join(WP, "mail-ledger.md")
 
 led = io.open(LEDGER, encoding="utf-8", errors="replace").read()
 
-# every office-sent delivery, handle -> earliest date
+# ── RENAME-AWARE (town #2622, 2026-09-10) ───────────────────────────────────
+#
+# A ledger row keeps THE HANDLE OF ITS DAY. This audit keyed on that handle and
+# compared it to today's folder names, so the committed wesley-seeker →
+# eloise-stellanova rename reported her as joined 2026-09-03 with zero office
+# letters and NEVER welcomed: 1 — while her welcome and its follow-up sat in
+# WHITE_PAGES/eloise-stellanova/inbox/, delivered under the prior handle. A
+# duplicate welcome is a worse failure than a late one (this file's own step in
+# postmaster-oversight-round.md says so), so this had to stop being possible.
+#
+# THE REGISTRY IS THE ONE HOME FOR THE EDGE. tools/rename-handle.mjs writes it,
+# ADD-never-remove: the old handle survives carrying the same account id, with
+# `retired:` and `renamed_to:`. tools/room-for.mjs is the node reader of exactly
+# this record, used by tools/reconcile.mjs; this is its python twin, folding the
+# SAME FILE by the same rule. Two languages, one record — and one falsifier
+# (tools/room-for.test.mjs) drives BOTH, by running this script.
+#
+# BY THE ROW'S DATE, not merely by handle: a row written after the handle was
+# retired did not reach the room the rename made, because the folder was gone.
+# Ferry's line on #2622 governs it — "a true absent artifact must still stay
+# loud" — so such a row keeps its original handle and stays unmatched.
+REGISTRY = os.path.join(ROOT, "tools", "github-ids.json")
+try:
+    registry = json.load(io.open(REGISTRY, encoding="utf-8"))
+except Exception as e:
+    # LOUD, never a quiet fall back to handle-only: a silent degrade here
+    # reprints the exact rows this fix exists to remove, and a reader has no
+    # way to tell the two reports apart.
+    sys.stderr.write("welcome-audit: could not read %s (%s) — the rename fold is "
+                     "unavailable and this report would name renamed residents as "
+                     "never welcomed. Refusing rather than reporting.\n" % (REGISTRY, e))
+    sys.exit(1)
+
+
+def room_for(handle, at_date=None):
+    """The room a handle's mail is in today. Mirrors tools/room-for.mjs."""
+    seen = {handle}
+    at = handle
+    while True:
+        row = registry.get(at) or {}
+        to = row.get("renamed_to")
+        if not to:
+            return at
+        retired = row.get("retired")
+        if at_date and retired and str(at_date) > str(retired):
+            return at          # the row postdates the room — stay loud
+        if to in seen:
+            return at          # a looping registry is read by hand, not here
+        seen.add(to)
+        at = to
+
+
+# every handle that folds into a given room, the room itself included — so the
+# inbound count below counts a resident's whole correspondence and not only the
+# part addressed to the name they use now.
+aliases = {}
+for h in registry:
+    aliases.setdefault(room_for(h), set()).add(h)
+
+# every office-sent delivery, ROOM -> earliest date
 office_to = {}
 for m in re.finditer(r"^- (\d{4}-\d{2}-\d{2}) · (\S+) · postmaster → (\S+) ", led, re.M):
     date, lid, who = m.group(1), m.group(2), m.group(3)
+    who = room_for(who, date)
     prev = office_to.get(who)
     if prev is None or date < prev[0]:
         office_to[who] = (date, lid)
@@ -82,7 +142,12 @@ for h in rooms:
     joined = fm.get("joined", "") or fm.get("since", "")
     got = office_to.get(h)
     if got is None:
-        never.append((joined or "?", h, int(len(re.findall(r"→ " + re.escape(h) + r" ", led)))))
+        # counted over every handle this room has ever answered to (#2622) —
+        # a resident who was written to twelve times under a prior name has not
+        # had "almost nobody write either".
+        inbound = sum(len(re.findall(r"→ " + re.escape(a) + r" ", led))
+                      for a in sorted(aliases.get(h, {h})))
+        never.append((joined or "?", h, int(inbound)))
     elif joined and got[0] > joined:
         # more than one crossing late = the day after the merge or worse
         d1 = joined.replace("-", "")

--- a/tools/reconcile.mjs
+++ b/tools/reconcile.mjs
@@ -44,6 +44,10 @@
 import { appendFileSync, existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+// The rename edge, folded in one place and read by both office audits
+// (tools/room-for.mjs; the welcome audit's python twin folds the same
+// registry file). Town #2622.
+import { loadRegistry, roomFor } from './room-for.mjs';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_REPO = resolve(SCRIPT_DIR, '..');
@@ -206,6 +210,7 @@ function main() {
   }
 
   const { deliveries, bouncedPaths } = parseLedger(repo);
+  const registry = loadRegistry(repo);
   const rooms = listRoomDirs(repo);
   const now = Date.now();
   const maxAgeMs = options.maxAgeDays * 24 * 60 * 60 * 1000;
@@ -262,14 +267,35 @@ function main() {
   }
 
   // Pass 3: ledger deliveries with no file on disk in the recipient's inbox.
+  //
+  // ── RENAME-AWARE (town #2622, 2026-09-10) ────────────────────────────────
+  //
+  // A ledger row keeps the handle of ITS OWN DAY, and this pass used to look up
+  // that handle against today's folders — so a rename read as two lost letters
+  // (`recipient room "wesley-seeker" not found`, both artifacts sitting in
+  // eloise-stellanova's inbox). `roomFor` folds the registry's rename lines,
+  // which tools/rename-handle.mjs has been writing all along.
+  //
+  // Resolved BY THE ROW'S DATE, not merely by handle: a row written after the
+  // handle was retired did not reach the room the rename made — the folder was
+  // gone — and Ferry's own line on #2622 governs that case, "a true absent
+  // artifact must still stay loud". `roomFor` returns the unmoved handle there,
+  // so the row lands in MISSING exactly as it did before.
+  //
+  // The reason string SAYS when a redirect happened. An audit that quietly
+  // resolves is an audit whose reader cannot tell a rename from a delivery.
   for (const [id, d] of deliveries) {
-    const ids = inboxIdsByRoom.get(d.to);
+    const resolved = roomFor(registry, d.to, d.date ?? null);
+    const ids = inboxIdsByRoom.get(resolved.room);
+    const via = resolved.renamed ? ` (via the registry's rename ${resolved.chain.join(' → ')})` : '';
     if (!ids) {
-      missing.push({ id, ...d, reason: `recipient room "${d.to}" not found` });
+      missing.push({ id, ...d, room: resolved.room, renamed: resolved.renamed,
+        reason: `recipient room "${resolved.room}" not found${resolved.reason ? ` — ${resolved.reason}` : ''}` });
       continue;
     }
     if (!ids.has(id)) {
-      missing.push({ id, ...d, reason: 'no file with this id in recipient inbox' });
+      missing.push({ id, ...d, room: resolved.room, renamed: resolved.renamed,
+        reason: `no file with this id in recipient inbox${via}` });
     }
   }
 

--- a/tools/room-for.mjs
+++ b/tools/room-for.mjs
@@ -1,0 +1,95 @@
+// room-for.mjs — which ROOM does a historical handle stand in today?
+//
+// Town #2622 (Ferry, 2026-09-09). Two office instruments lost the same resident
+// across the committed `wesley-seeker` → `eloise-stellanova` rename, even though
+// the paper moved intact and the immutable GitHub id never changed:
+//
+//   reconcile.mjs   two delivered letters became MISSING, both reading
+//                   `recipient room "wesley-seeker" not found`, while both
+//                   artifacts sat in WHITE_PAGES/eloise-stellanova/inbox/
+//   welcome-audit   `eloise-stellanova` read as joined with zero office letters
+//                   and therefore NEVER welcomed: 1 — her welcome and its
+//                   follow-up were delivered under the prior handle
+//
+// Both instruments resolve a LEDGER ROW's recipient to a room by the handle
+// written on the row, and a row keeps the handle of its day. The registry
+// already carries the edge — `tools/rename-handle.mjs` writes it, ADD-never-
+// remove, and the invariant is that the old handle survives carrying the same
+// account id:
+//
+//   "wesley-seeker": { "login": "wesleymons22-coder", "id": 324643059,
+//                      "pinned": "2026-09-04", "retired": "2026-09-09",
+//                      "renamed_to": "eloise-stellanova" }
+//
+// So the record had what the audits needed and they did not read it. This is
+// that read, in one place, so a rename can never again present as lost mail or
+// as an owed welcome.
+//
+// ── WHY THE DATE IS AN ARGUMENT ─────────────────────────────────────────────
+//
+// `atDate` is the LEDGER ROW'S OWN DATE, and it is the difference between
+// following a rename and inventing one. The physical move is what makes the
+// redirect true: `WHITE_PAGES/wesley-seeker/` BECAME
+// `WHITE_PAGES/eloise-stellanova/`, so mail delivered before the rename is in
+// the new room and mail "delivered" to the old handle afterwards is not — the
+// folder was gone. A row dated after the retirement that still names the old
+// handle is a genuine anomaly, and Ferry's own line on #2622 governs it: "A
+// true absent artifact must still stay loud."
+//
+// Called with no date, this follows the chain unconditionally — the right
+// reading for "where does this person live now", which is what the welcome
+// audit asks of a ROOM rather than of a row.
+//
+// Chains fold (a → b → c), each hop tested against its own `retired` stamp,
+// with a seen-set so a registry that ever gained a cycle reports a cycle
+// instead of hanging the round that runs it.
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const REGISTRY_REL = 'tools/github-ids.json';
+
+export function loadRegistry(repo = join(dirname(fileURLToPath(import.meta.url)), '..')) {
+  return JSON.parse(readFileSync(join(repo, ...REGISTRY_REL.split('/')), 'utf8'));
+}
+
+/**
+ * The room a handle's mail is in today.
+ *
+ * @param {object} registry  tools/github-ids.json, parsed
+ * @param {string} handle    the handle as written on the row
+ * @param {string|null} atDate  the row's own YYYY-MM-DD, or null for "now"
+ * @returns {{ room: string, renamed: boolean, chain: string[], reason: string|null }}
+ *   `room` is always a handle — the original one when nothing redirects it, so
+ *   a caller can use the answer unconditionally. `renamed` says whether the
+ *   record moved it, which is what a report needs to explain itself.
+ */
+export function roomFor(registry, handle, atDate = null) {
+  const chain = [handle];
+  const seen = new Set([handle]);
+  let at = handle;
+
+  for (;;) {
+    const row = registry?.[at];
+    const to = row?.renamed_to;
+    if (!to) break;
+
+    // The one guard: a row written AFTER the handle was retired did not go to
+    // the room the rename made, because the old folder no longer existed to
+    // receive it. Stay loud rather than redirect it somewhere plausible.
+    if (atDate && row.retired && String(atDate) > String(row.retired)) {
+      return { room: at, renamed: chain.length > 1, chain,
+        reason: `"${at}" was retired ${row.retired}; this row is dated ${atDate}, after the room was gone` };
+    }
+    if (seen.has(to)) {
+      return { room: at, renamed: chain.length > 1, chain: [...chain, to],
+        reason: `the registry's rename chain loops at "${to}" — read it by hand` };
+    }
+    seen.add(to);
+    chain.push(to);
+    at = to;
+  }
+
+  return { room: at, renamed: chain.length > 1, chain, reason: null };
+}

--- a/tools/room-for.test.mjs
+++ b/tools/room-for.test.mjs
@@ -1,0 +1,172 @@
+// room-for.test.mjs — a rename is not lost mail, and it is not an owed welcome.
+//   node --test tools/room-for.test.mjs
+// Zero-dep. The synthetic half is pure; the live half drives BOTH audits
+// against this repo, because a resolver nobody calls fixes nothing.
+//
+// Town #2622 (Ferry, 2026-09-09): across the committed `wesley-seeker` →
+// `eloise-stellanova` rename, reconcile reported two delivered letters as
+// MISSING (`recipient room "wesley-seeker" not found`, both artifacts present
+// in eloise's inbox) and the welcome audit reported `NEVER welcomed: 1` for a
+// resident whose welcome and follow-up had both been delivered under the prior
+// handle. The registry carried the edge the whole time and neither read it.
+//
+// THE FLIP, for whoever reruns this: revert `roomFor` out of reconcile.mjs's
+// pass 3 and the `room_for` fold out of welcome-audit.py. The two live tests at
+// the bottom then reproduce this issue's exact rows — the three MISSING and the
+// NEVER-welcomed one. Recorded on the branch, both directions.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadRegistry, roomFor } from './room-for.mjs';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// ── THE RESOLVER, on shapes it can be handed ────────────────────────────────
+
+test('a live handle resolves to itself, and says nothing moved', () => {
+  const reg = { alice: { id: 1 } };
+  const r = roomFor(reg, 'alice');
+  assert.equal(r.room, 'alice');
+  assert.equal(r.renamed, false);
+  assert.equal(r.reason, null);
+});
+
+test('a handle the registry has never heard of comes back unchanged', () => {
+  // The caller may then call it missing — that is the caller's judgment, and
+  // this read must not silently invent a room for a stranger.
+  assert.equal(roomFor({}, 'nobody').room, 'nobody');
+  assert.equal(roomFor(null, 'nobody').room, 'nobody');
+});
+
+test('a retired handle resolves to the room the rename made', () => {
+  const reg = {
+    'wesley-seeker': { id: 7, retired: '2026-09-09', renamed_to: 'eloise-stellanova' },
+    'eloise-stellanova': { id: 7 },
+  };
+  const r = roomFor(reg, 'wesley-seeker', '2026-09-04');
+  assert.equal(r.room, 'eloise-stellanova');
+  assert.equal(r.renamed, true);
+  assert.deepEqual(r.chain, ['wesley-seeker', 'eloise-stellanova']);
+});
+
+test('a row dated AFTER the retirement stays loud — the folder was gone', () => {
+  // Ferry's own line on #2622: "A true absent artifact must still stay loud."
+  // The redirect is true because the FOLDER MOVED; a delivery claimed after the
+  // move could not have landed in the room the rename made, and resolving it
+  // there would turn a real anomaly into a tidy answer.
+  const reg = {
+    'wesley-seeker': { id: 7, retired: '2026-09-09', renamed_to: 'eloise-stellanova' },
+    'eloise-stellanova': { id: 7 },
+  };
+  const r = roomFor(reg, 'wesley-seeker', '2026-09-15');
+  assert.equal(r.room, 'wesley-seeker', 'a post-retirement row was quietly redirected');
+  assert.match(r.reason, /retired 2026-09-09.*dated 2026-09-15/);
+  // The boundary belongs to the old room: a letter delivered ON the day of the
+  // rename went into the folder that still existed when the ferry moved it.
+  assert.equal(roomFor(reg, 'wesley-seeker', '2026-09-09').room, 'eloise-stellanova');
+});
+
+test('with no date the chain folds unconditionally — the "where do they live now" read', () => {
+  const reg = {
+    a: { id: 1, retired: '2026-01-01', renamed_to: 'b' },
+    b: { id: 1, retired: '2026-02-01', renamed_to: 'c' },
+    c: { id: 1 },
+  };
+  assert.equal(roomFor(reg, 'a').room, 'c');
+  assert.deepEqual(roomFor(reg, 'a').chain, ['a', 'b', 'c']);
+  // dated, the whole chain still folds while the row predates the first
+  // retirement — the hops are in the order the renames happened
+  assert.equal(roomFor(reg, 'a', '2025-12-31').room, 'c');
+  // and a row after the first retirement stops at the first hop, loud
+  assert.equal(roomFor(reg, 'a', '2026-01-15').room, 'a');
+});
+
+test('each hop is tested against ITS OWN retired stamp, not the first one\'s', () => {
+  // On a well-formed chain the stamps only ever increase, so the per-hop guard
+  // is unreachable — which is exactly why it has to be exercised on a chain
+  // that is NOT well formed. A registry whose second stamp predates its first
+  // is a record somebody edited by hand, and the resolver's job there is to
+  // stop at the last hop it can justify rather than to trust the tail.
+  const bent = {
+    a: { renamed_to: 'b', retired: '2026-03-01' },
+    b: { renamed_to: 'c', retired: '2026-01-01' },
+    c: {},
+  };
+  const r = roomFor(bent, 'a', '2026-02-01');
+  assert.equal(r.room, 'b', 'the resolver followed a hop the row postdates');
+  assert.equal(r.renamed, true);
+  assert.match(r.reason, /"b" was retired 2026-01-01.*dated 2026-02-01/);
+});
+
+test('a looping registry reports the loop instead of hanging the round', () => {
+  const reg = { a: { renamed_to: 'b' }, b: { renamed_to: 'a' } };
+  const r = roomFor(reg, 'a');
+  assert.match(r.reason, /loops at "a"/);
+});
+
+// ── THE RECORD THIS TOWN ACTUALLY CARRIES ───────────────────────────────────
+
+test('the live registry still carries both rename edges #2622 names', () => {
+  // If a future tidy-up ever deletes a retired handle, the audits go blind
+  // again and every assertion below would pass against an empty answer. This
+  // is the check that the RECORD, not merely the reader, is intact.
+  const reg = loadRegistry(REPO);
+  assert.equal(reg['wesley-seeker'].renamed_to, 'eloise-stellanova');
+  assert.equal(reg['wesley-seeker'].retired, '2026-09-09');
+  assert.equal(reg['wesley-seeker'].id, reg['eloise-stellanova'].id,
+    'the rename invariant is the immutable account id — it must not have moved');
+  assert.equal(reg['dylan-android-husband'].renamed_to, 'dylan');
+  assert.equal(reg['dylan-android-husband'].id, reg.dylan.id);
+
+  // the two ledger rows the issue names, by their own dates
+  assert.equal(roomFor(reg, 'wesley-seeker', '2026-09-04').room, 'eloise-stellanova');
+  assert.equal(roomFor(reg, 'wesley-seeker', '2026-09-05').room, 'eloise-stellanova');
+  assert.equal(roomFor(reg, 'dylan-android-husband', '2026-07-20').room, 'dylan');
+});
+
+// ── THE TWO AUDITS, DRIVEN ──────────────────────────────────────────────────
+//
+// Asserted on THE NAMED ROWS rather than on a total. "MISSING is 0" would go
+// red the first time the town loses a real letter for a real reason, which is
+// the calendar-pinned-control class: a check that fails on something other than
+// the thing it is watching stops being read.
+
+test('reconcile no longer calls the renamed resident\'s delivered mail MISSING', { timeout: 180000 }, () => {
+  const r = spawnSync(process.execPath, [join(REPO, 'tools', 'reconcile.mjs'), '--repo', REPO, '--json'],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  assert.equal(r.status, 0, r.stderr);
+  const report = JSON.parse(r.stdout);
+  const missingIds = new Set(report.missing.map((m) => m.id));
+  for (const id of ['postmaster-2026-09-04-welcome-wesley-seeker',
+    'postmaster-2026-09-05-followup-wesley-seeker']) {
+    assert.ok(!missingIds.has(id), `${id} is MISSING again — the rename fold is not being read`);
+  }
+  // THE PREMISE, MEASURED. The assertion above is only about the resolver if
+  // the ledger still names the OLD handle. #2622 explicitly asked nobody to
+  // rewrite the ledger ("those are the history that proves the move"), so a
+  // rewritten row would make this test pass for the wrong reason and hide the
+  // regression it exists to catch.
+  const ledger = readFileSync(join(REPO, 'WHITE_PAGES', 'mail-ledger.md'), 'utf8');
+  assert.match(ledger,
+    /^- 2026-09-04 · postmaster-2026-09-04-welcome-wesley-seeker · postmaster → wesley-seeker /m,
+    'the ledger no longer names the prior handle — this test would now pass with the fold removed');
+  assert.match(ledger,
+    /^- 2026-09-05 · postmaster-2026-09-05-followup-wesley-seeker · postmaster → wesley-seeker /m);
+  // and the paper really is in the new room
+  assert.ok(existsSync(join(REPO, 'WHITE_PAGES', 'eloise-stellanova', 'inbox',
+    'postmaster-2026-09-04-welcome-wesley-seeker.md')), 'the artifact is not where the rename put it');
+});
+
+test('the welcome audit no longer owes the renamed resident a welcome', { timeout: 180000 }, () => {
+  const audit = join(REPO, 'MEEPS', 'postmaster', 'memory', 'welcome-audit.py');
+  const r = spawnSync('python', [audit], { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+  assert.equal(r.status, 0,
+    `the welcome audit did not run (${r.error?.code ?? r.status}): ${r.stderr}\n`
+    + 'python is required for this check — it drives the audit rather than reasoning about it');
+  assert.doesNotMatch(r.stdout, /^ +\S+ +eloise-stellanova /m,
+    'eloise-stellanova is on the NEVER-welcomed list again — a duplicate welcome is a worse failure than a late one');
+});


### PR DESCRIPTION
Closes #2622.

Both office instruments resolve a **ledger row's** recipient to a room by the handle written on the row, and a row keeps the handle of its day. The registry has carried the rename edge all along — `tools/rename-handle.mjs` writes it ADD-never-remove, the old handle surviving with the same account id — and neither audit read it.

`tools/room-for.mjs` is that read, in one place: `roomFor(registry, handle, atDate)` folds the chain and answers the current room.

**By the row's date, and that argument is the whole design.** The redirect is true because the *folder moved*, so a row written after the handle was retired did not reach the room the rename made. Ferry's own line governs it: *"A true absent artifact must still stay loud."* Such a row keeps its original handle and lands in MISSING exactly as before. Called with no date, the chain folds unconditionally — the right reading of "where does this person live now", which is what the welcome audit asks of a room rather than of a row.

**Two languages, one record.** The welcome audit is python and cannot import the node resolver, so it folds the same registry file by the same rule — and it *refuses* rather than degrading if it cannot read that file, because a silent fall back to handle-only reprints the exact rows this fix removes and a reader could not tell the two reports apart. One falsifier drives both: `tools/room-for.test.mjs` runs reconcile **and** the python audit for real.

## Live on this town, both directions

| instrument | with the fold | flipped out |
|---|---|---|
| `reconcile` MISSING | 0 | 3 — `postmaster-2026-08-03-welcome-dylan-android-husband`, `postmaster-2026-09-04-welcome-wesley-seeker`, `postmaster-2026-09-05-followup-wesley-seeker` |
| `welcome-audit` NEVER welcomed | 0 | 1 — `eloise-stellanova`, joined 2026-09-03 |

The flip reproduces this issue's exact rows, the historical Dylan one included — it is the same class and closes with it.

## Falsifiers

`tools/room-for.test.mjs`, ten, all green. The resolver on a live handle, an unknown handle, a retired handle, a row dated after the retirement (stays loud; the boundary day still folds), a multi-hop chain, a **bent** chain whose second stamp predates its first — the only shape that exercises the per-hop guard, since a well-formed chain's stamps only ever increase — and a loop. Plus: the live registry still carrying both edges with the id invariant intact, and the two audits driven end to end.

The audit assertions name **the rows**, not a total. "MISSING is 0" would go red the first time the town loses a real letter for a real reason, and a check that fails on something other than the thing it watches stops being read. The reconcile test also measures its own premise — that the ledger still names the prior handle, which #2622 asked nobody to rewrite; a rewritten row would make the test pass for the wrong reason.

Nothing in the ledger or the resident paper was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDJ7RsS1Mykj4YMnBhphy4
